### PR TITLE
fix(#249): add body to error response to prevent 5xx error

### DIFF
--- a/scripts/cloudfront_routing.js
+++ b/scripts/cloudfront_routing.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+var NOT_FOUND_BODY = '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>404 - Page Not Found</h1></body></html>';
+
 var ROUTE_MAP = Object.freeze({
   '/': '/index.html',
   '/about': '/about/index.html',
@@ -54,7 +56,7 @@ function handler(event) {
           'cache-control': { value: 'public, max-age=60' },
           'content-type': { value: 'text/html; charset=utf-8' }
         },
-        body: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>404 - Page Not Found</h1></body></html>'
+        body: NOT_FOUND_BODY
       };
     }
 

--- a/scripts/cloudfront_routing.js
+++ b/scripts/cloudfront_routing.js
@@ -54,6 +54,7 @@ function handler(event) {
           'cache-control': { value: 'public, max-age=60' },
           'content-type': { value: 'text/html; charset=utf-8' }
         },
+        body: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>404 - Page Not Found</h1></body></html>'
       };
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the required body field to the 404 response object in the CloudFront routing function. When CloudFront Functions return a response object (instead of a request), AWS requires the body field to be present. Without it, CloudFront cannot construct a valid HTTP response and returns a 5xx error instead.

## Related Issue
Fixes #249 

## Motivation and Context
PR #248 fixed a Safari browser issue (#235) by adding the content-type header to the 404 response. However, it didn't include the mandatory body field required by AWS CloudFront Functions when returning response objects.

## How Has This Been Tested?
- Monitor CloudWatch alarm website-prod-cloudfront-staging-5xx-errors-alarm
- Test unmapped single-segment paths (e.g., /nonexistent) return 404 with proper body
- Verify staging distribution 5xx error rate drops to 0%
- Confirm Safari fix from PR #248 still works (headers preserved)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/frontend-ssr-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] New components have been added to Storybook.
- [ ] You have only one commit (if not, squash them into one commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 404 responses for single-segment URLs now include a full HTML error page instead of an empty/body-less response.
  * Users will see a readable 404 page in browsers and developer tools.
  * Behavior for multi-segment URLs and other error paths remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->