### PR TITLE
fix(#251): add public ecr usage to resolve 429 error in the Apollo.Do…

### DIFF
--- a/Apollo.Dockerfile
+++ b/Apollo.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23.11.1-alpine3.21
+FROM public.ecr.aws/docker/library/node:23.11.1-alpine3.21 AS base
 
 RUN apk add --no-cache curl=8.14.1-r2
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the Dockerfile to pull the Node.js base image from AWS Public ECR instead of Docker Hub. This change prevents Docker Hub rate limiting (429 Too Many Requests) errors during AWS CodeBuild execution.

## Related Issue
Fixes #251 

## Motivation and Context
Docker Hub enforces rate limits for unauthenticated users, which can interrupt automated builds in environments like AWS CodeBuild.
Using the AWS Public ECR mirror for the node:23.11.1-alpine3.21 image ensures consistent and authenticated access without rate limiting.

## How Has This Been Tested?
Updated the Dockerfile with the following line:
  - FROM public.ecr.aws/docker/library/node:23.11.1-alpine3.21 AS base
Triggered a CodeBuild run through the pipeline.
Verified that the image pulled successfully from AWS Public ECR and that the build completed without errors.
Confirmed no regressions or changes in build behavior beyond the improved stability.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/frontend-ssr-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] New components have been added to Storybook.
- [x] You have only one commit (if not, squash them into one commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image source configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->