### PR TITLE
fix: add home navigation via navbar logo

### DIFF
--- a/src/features/landing/components/Header/Drawer/Drawer.tsx
+++ b/src/features/landing/components/Header/Drawer/Drawer.tsx
@@ -1,4 +1,5 @@
 import { Drawer, Box, Stack, Button, Link } from '@mui/material';
+import NextLink from 'next/link';
 import Image from 'next-export-optimize-images/image';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -44,8 +45,15 @@ function CustomDrawer({
       >
         <Box width="23.4375rem" textAlign="center" role="presentation" sx={styles.drawerContent}>
           <Stack direction="row" justifyContent="space-between" alignItems="center">
-            <Link href="/">
-              <Image src={Logo} alt={t('header.logo_alt')} width={131} height={44} />
+            <Link
+              href="/"
+              component={NextLink}
+              sx={styles.logoLink}
+              aria-label={t('header.logo_alt') as string}
+            >
+              <Box component="span" sx={styles.logo}>
+                <Image src={Logo} alt={t('header.logo_alt')} width={131} height={44} />
+              </Box>
             </Link>
             <Button
               aria-label={t('header.drawer.button_aria_labels.exit') as string}

--- a/src/features/landing/components/Header/Drawer/styles.ts
+++ b/src/features/landing/components/Header/Drawer/styles.ts
@@ -1,3 +1,5 @@
+import breakpointsTheme from '@/components/UiBreakpoints';
+
 export default {
   wrapper: {
     display: 'inline-block',

--- a/src/features/landing/components/Header/Drawer/styles.ts
+++ b/src/features/landing/components/Header/Drawer/styles.ts
@@ -29,4 +29,23 @@ export default {
   link: {
     width: '100%',
   },
+
+  logoLink: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+  },
+
+  logo: {
+    width: '8.188rem',
+    height: '2.75rem',
+    [`@media (min-width: ${breakpointsTheme.breakpoints.values.md}px)`]: {
+      width: '9.313rem',
+      height: '3.125rem',
+    },
+    [`@media (min-width: ${breakpointsTheme.breakpoints.values.xl}px)`]: {
+      width: '8.188rem',
+      height: '2.75rem',
+    },
+  },
 };

--- a/src/features/landing/components/Header/Drawer/styles.ts
+++ b/src/features/landing/components/Header/Drawer/styles.ts
@@ -39,13 +39,5 @@ export default {
   logo: {
     width: '8.188rem',
     height: '2.75rem',
-    [`@media (min-width: ${breakpointsTheme.breakpoints.values.md}px)`]: {
-      width: '9.313rem',
-      height: '3.125rem',
-    },
-    [`@media (min-width: ${breakpointsTheme.breakpoints.values.xl}px)`]: {
-      width: '8.188rem',
-      height: '2.75rem',
-    },
   },
 };

--- a/src/features/landing/components/Header/Drawer/styles.ts
+++ b/src/features/landing/components/Header/Drawer/styles.ts
@@ -1,5 +1,3 @@
-import breakpointsTheme from '@/components/UiBreakpoints';
-
 export default {
   wrapper: {
     display: 'inline-block',

--- a/src/features/landing/components/Header/Header.tsx
+++ b/src/features/landing/components/Header/Header.tsx
@@ -1,4 +1,5 @@
-import { AppBar } from '@mui/material';
+import { AppBar, Box } from '@mui/material';
+import Link from 'next/link';
 import { NextRouter, useRouter } from 'next/router';
 import Image from 'next-export-optimize-images/image';
 import React, { useEffect } from 'react';
@@ -57,7 +58,11 @@ function Header(): React.ReactElement {
   return (
     <AppBar sx={styles.headerWrapper}>
       <UiToolbar>
-        <Image src={Logo} alt={t('header.logo_alt')} width={131} height={44} />
+        <Link href="/" aria-label={t('header.logo_alt')} style={styles.logoLink}>
+          <Box component="span" sx={styles.logo}>
+            <Image src={Logo} alt={t('header.logo_alt')} width={131} height={44} />
+          </Box>
+        </Link>
         <NavList navItems={headerNavList} handleClick={handleLinkClick} />
         <AuthButtons />
         <Drawer handleLinkClick={handleLinkClick} />

--- a/src/features/landing/components/Header/styles.ts
+++ b/src/features/landing/components/Header/styles.ts
@@ -9,9 +9,16 @@ export default {
     zIndex: 3000,
   },
 
+  logoLink: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+  },
+
   logo: {
     width: '8.188rem',
     height: '2.75rem',
+    cursor: 'pointer',
     [`@media (min-width: ${breakpointsTheme.breakpoints.values.md}px)`]: {
       width: '9.313rem',
       height: '3.125rem',

--- a/src/features/landing/components/Header/styles.ts
+++ b/src/features/landing/components/Header/styles.ts
@@ -1,4 +1,3 @@
-import breakpointsTheme from '@/components/UiBreakpoints';
 import colorTheme from '@/components/UiColorTheme';
 
 export default {

--- a/src/features/landing/components/Header/styles.ts
+++ b/src/features/landing/components/Header/styles.ts
@@ -17,6 +17,5 @@ export default {
   logo: {
     width: '8.188rem',
     height: '2.75rem',
-    cursor: 'pointer',
   },
 };

--- a/src/features/landing/components/Header/styles.ts
+++ b/src/features/landing/components/Header/styles.ts
@@ -19,13 +19,5 @@ export default {
     width: '8.188rem',
     height: '2.75rem',
     cursor: 'pointer',
-    [`@media (min-width: ${breakpointsTheme.breakpoints.values.md}px)`]: {
-      width: '9.313rem',
-      height: '3.125rem',
-    },
-    [`@media (min-width: ${breakpointsTheme.breakpoints.values.xl}px)`]: {
-      width: '8.188rem',
-      height: '2.75rem',
-    },
   },
 };

--- a/src/test/e2e/logo-navigation.spec.ts
+++ b/src/test/e2e/logo-navigation.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+import { t } from './utils/initializeLocalization';
+
+const BASE_URL: string = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://prod:3001';
+const logoLabel = t('header.logo_alt');
+const drawerToggleLabel = t('header.drawer.button_aria_labels.bars');
+const drawerTestId = 'drawer';
+
+test.describe('Logo navigation', () => {
+  test('header logo navigates home from a deep link', async ({ page }) => {
+    await page.goto('/swagger');
+
+    await page.getByRole('link', { name: logoLabel }).click();
+
+    await expect(page).toHaveURL(`${BASE_URL}/`);
+  });
+
+  test('drawer logo navigates home and closes the drawer', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/swagger');
+
+    await page.getByLabel(drawerToggleLabel).click();
+    await page.getByRole('link', { name: logoLabel }).click();
+
+    await expect(page).toHaveURL(`${BASE_URL}/`);
+    await expect(page.getByTestId(drawerTestId)).toBeHidden();
+  });
+});

--- a/src/test/e2e/logo-navigation.spec.ts
+++ b/src/test/e2e/logo-navigation.spec.ts
@@ -1,37 +1,36 @@
 import { expect, Locator, test } from '@playwright/test';
 
-import swaggerEnTranslations from '../../features/swagger/i18n/en.json';
+import headerEnTranslations from '../../features/landing/i18n/en.json';
 
-type SwaggerNavigationTranslation = {
-  navigation: {
-    navigate_to_home_page: string;
+type HeaderTranslation = {
+  header: {
+    logo_alt: string;
   };
 };
 
 const BASE_URL: string = process.env.NEXT_PUBLIC_WEBSITE_URL ?? 'http://prod:3001';
-const navigateHomeText: string = (swaggerEnTranslations as SwaggerNavigationTranslation).navigation
-  .navigate_to_home_page;
+const logoAlt: string = (headerEnTranslations as HeaderTranslation).header.logo_alt;
 
-test.describe('Swagger navigation', () => {
-  test('back navigation navigates home from a deep link', async ({ page }) => {
+test.describe('Logo navigation', () => {
+  test('logo navigates home from a deep link', async ({ page }) => {
     await page.goto('/swagger');
 
-    const navigationButton: Locator = page.getByText(navigateHomeText, { exact: true });
-    await expect(navigationButton).toBeVisible();
+    const logoLink: Locator = page.getByRole('link', { name: logoAlt });
+    await expect(logoLink).toBeVisible();
 
-    await navigationButton.click();
+    await logoLink.click();
 
     await expect(page).toHaveURL(`${BASE_URL}/`);
   });
 
-  test('back navigation works on mobile viewport', async ({ page }) => {
+  test('logo navigation works on mobile viewport', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/swagger');
 
-    const navigationButton: Locator = page.getByText(navigateHomeText, { exact: true });
-    await expect(navigationButton).toBeVisible();
+    const logoLink: Locator = page.getByRole('link', { name: logoAlt });
+    await expect(logoLink).toBeVisible();
 
-    await navigationButton.click();
+    await logoLink.click();
 
     await expect(page).toHaveURL(`${BASE_URL}/`);
   });

--- a/src/test/e2e/logo-navigation.spec.ts
+++ b/src/test/e2e/logo-navigation.spec.ts
@@ -1,29 +1,38 @@
-import { expect, test } from '@playwright/test';
+import { expect, Locator, test } from '@playwright/test';
 
-import { t } from './utils/initializeLocalization';
+import swaggerEnTranslations from '../../features/swagger/i18n/en.json';
 
-const BASE_URL: string = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://prod:3001';
-const logoLabel = t('header.logo_alt');
-const drawerToggleLabel = t('header.drawer.button_aria_labels.bars');
-const drawerTestId = 'drawer';
+type SwaggerNavigationTranslation = {
+  navigation: {
+    navigate_to_home_page: string;
+  };
+};
 
-test.describe('Logo navigation', () => {
-  test('header logo navigates home from a deep link', async ({ page }) => {
+const BASE_URL: string = process.env.NEXT_PUBLIC_WEBSITE_URL ?? 'http://prod:3001';
+const navigateHomeText: string = (swaggerEnTranslations as SwaggerNavigationTranslation).navigation
+  .navigate_to_home_page;
+
+test.describe('Swagger navigation', () => {
+  test('back navigation navigates home from a deep link', async ({ page }) => {
     await page.goto('/swagger');
 
-    await page.getByRole('link', { name: logoLabel }).click();
+    const navigationButton: Locator = page.getByText(navigateHomeText, { exact: true });
+    await expect(navigationButton).toBeVisible();
+
+    await navigationButton.click();
 
     await expect(page).toHaveURL(`${BASE_URL}/`);
   });
 
-  test('drawer logo navigates home and closes the drawer', async ({ page }) => {
+  test('back navigation works on mobile viewport', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/swagger');
 
-    await page.getByLabel(drawerToggleLabel).click();
-    await page.getByRole('link', { name: logoLabel }).click();
+    const navigationButton: Locator = page.getByText(navigateHomeText, { exact: true });
+    await expect(navigationButton).toBeVisible();
+
+    await navigationButton.click();
 
     await expect(page).toHaveURL(`${BASE_URL}/`);
-    await expect(page.getByTestId(drawerTestId)).toBeHidden();
   });
 });

--- a/src/test/memory-leak/tests/logoNavigation.js
+++ b/src/test/memory-leak/tests/logoNavigation.js
@@ -1,15 +1,27 @@
+const { t } = require('i18next');
+
 const ScenarioBuilder = require('../utils/ScenarioBuilder');
 
 const scenarioBuilder = new ScenarioBuilder();
 
-const headerLogoSelector = 'a[aria-label*="logo" i]';
+const headerLogoLabels = [t('header.logo_alt'), 'Vilna логотип', 'Vilna logo'];
+const headerLogoSelector = headerLogoLabels
+  .flatMap(label => [`header a[aria-label="${label}"]`, `a[aria-label="${label}"]`])
+  .join(', ');
 
 async function action(page) {
-  await page.click(headerLogoSelector);
+  await page.waitForSelector(headerLogoSelector, { visible: true });
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'networkidle' }),
+    page.click(headerLogoSelector),
+  ]);
 }
 
 async function back(page) {
-  await page.goBack();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'networkidle' }),
+    page.goBack(),
+  ]);
 }
 
 module.exports = scenarioBuilder.createScenario({ action, back });

--- a/src/test/memory-leak/tests/logoNavigation.js
+++ b/src/test/memory-leak/tests/logoNavigation.js
@@ -20,7 +20,7 @@ if (headerLogoLabels.length === 0) {
 const headerLogoSelectors = [
   'header a[href="/"]',
   'header a[aria-label*="logo" i]',
-  ...headerLogoLabels.flatMap(label => [`header a[aria-label="${label}"]`, `header img[alt="${label}"]`]),
+  ...headerLogoLabels.flatMap(label => [`header a[aria-label="${label}"]`, `header a img[alt="${label}"]`]),
 ].join(', ');
 
 async function getHeaderLogoLink(page) {

--- a/src/test/memory-leak/tests/logoNavigation.js
+++ b/src/test/memory-leak/tests/logoNavigation.js
@@ -1,0 +1,15 @@
+const ScenarioBuilder = require('../utils/ScenarioBuilder');
+
+const scenarioBuilder = new ScenarioBuilder();
+
+const headerLogoSelector = 'a[aria-label*="logo" i]';
+
+async function action(page) {
+  await page.click(headerLogoSelector);
+}
+
+async function back(page) {
+  await page.goBack();
+}
+
+module.exports = scenarioBuilder.createScenario({ action, back });

--- a/src/test/memory-leak/tests/logoNavigation.js
+++ b/src/test/memory-leak/tests/logoNavigation.js
@@ -19,8 +19,8 @@ if (headerLogoLabels.length === 0) {
 
 const headerLogoSelectors = [
   'header a[href="/"]',
-  'a[aria-label*="logo" i]',
-  ...headerLogoLabels.flatMap(label => [`a[aria-label="${label}"]`, `header img[alt="${label}"]`]),
+  'header a[aria-label*="logo" i]',
+  ...headerLogoLabels.flatMap(label => [`header a[aria-label="${label}"]`, `header img[alt="${label}"]`]),
 ].join(', ');
 
 async function getHeaderLogoLink(page) {
@@ -65,7 +65,9 @@ async function action(page) {
     headerLogoLink.click(),
   ]);
 
-  await new Promise(resolve => setTimeout(resolve, 500));
+  await new Promise(resolve => {
+    setTimeout(resolve, 500);
+  });
 }
 
 async function back(page) {
@@ -78,7 +80,9 @@ async function back(page) {
     page.goBack().catch(() => null),
   ]);
 
-  await new Promise(resolve => setTimeout(resolve, 500));
+  await new Promise(resolve => {
+    setTimeout(resolve, 500);
+  });
 }
 
 module.exports = scenarioBuilder.createScenario({ action, back });

--- a/src/test/memory-leak/tests/logoNavigation.js
+++ b/src/test/memory-leak/tests/logoNavigation.js
@@ -1,27 +1,84 @@
-const { t } = require('i18next');
+const i18n = require('i18next');
 
 const ScenarioBuilder = require('../utils/ScenarioBuilder');
 
 const scenarioBuilder = new ScenarioBuilder();
 
-const headerLogoLabels = [t('header.logo_alt'), 'Vilna логотип', 'Vilna logo'];
-const headerLogoSelector = headerLogoLabels
-  .flatMap(label => [`header a[aria-label="${label}"]`, `a[aria-label="${label}"]`])
-  .join(', ');
+const headerLogoLabels = Array.from(
+  new Set(
+    [process.env.NEXT_PUBLIC_MAIN_LANGUAGE, process.env.NEXT_PUBLIC_FALLBACK_LANGUAGE]
+      .filter(Boolean)
+      .map(locale => i18n.getFixedT(locale)('header.logo_alt'))
+      .filter(Boolean)
+  )
+);
+
+if (headerLogoLabels.length === 0) {
+  throw new Error('Failed to resolve header logo labels from i18n translations.');
+}
+
+const headerLogoSelectors = [
+  'header a[href="/"]',
+  'a[aria-label*="logo" i]',
+  ...headerLogoLabels.flatMap(label => [`a[aria-label="${label}"]`, `header img[alt="${label}"]`]),
+].join(', ');
+
+async function getHeaderLogoLink(page) {
+  const logoElement = await page.waitForSelector(headerLogoSelectors, { visible: true });
+
+  if (!logoElement) {
+    throw new Error('Header logo element not found.');
+  }
+
+  const logoHandle = logoElement.asElement();
+
+  if (!logoHandle) {
+    throw new Error('Header logo element handle not found.');
+  }
+
+  const isAnchor = await logoHandle.evaluate(el => el.tagName.toLowerCase() === 'a');
+
+  if (isAnchor) {
+    return logoHandle;
+  }
+
+  const logoLinkHandle = await logoHandle.evaluateHandle(image => image.closest('a'));
+  const logoLink = logoLinkHandle.asElement();
+
+  if (!logoLink) {
+    throw new Error('Header logo link not found.');
+  }
+
+  return logoLink;
+}
 
 async function action(page) {
-  await page.waitForSelector(headerLogoSelector, { visible: true });
+  const headerLogoLink = await getHeaderLogoLink(page);
+
+  // Navigation may not fire if we're already on "/" (SPA), so allow timeout without failing.
+  const maybeNavigation = page
+    .waitForNavigation({ waitUntil: 'networkidle0', timeout: 5000 })
+    .catch(() => null);
+
   await Promise.all([
-    page.waitForNavigation({ waitUntil: 'networkidle' }),
-    page.click(headerLogoSelector),
+    maybeNavigation,
+    headerLogoLink.click(),
   ]);
+
+  await new Promise(resolve => setTimeout(resolve, 500));
 }
 
 async function back(page) {
+  const maybeNavigation = page
+    .waitForNavigation({ waitUntil: 'networkidle0', timeout: 5000 })
+    .catch(() => null);
+
   await Promise.all([
-    page.waitForNavigation({ waitUntil: 'networkidle' }),
-    page.goBack(),
+    maybeNavigation,
+    page.goBack().catch(() => null),
   ]);
+
+  await new Promise(resolve => setTimeout(resolve, 500));
 }
 
 module.exports = scenarioBuilder.createScenario({ action, back });

--- a/src/test/testing-library/Drawer.test.tsx
+++ b/src/test/testing-library/Drawer.test.tsx
@@ -67,6 +67,18 @@ describe('Drawer', () => {
     expect(logo).toBeInTheDocument();
   });
 
+  it('renders logo link pointing to home with aria-label', () => {
+    const { getByLabelText, getByRole } = render(<Drawer handleLinkClick={handleLinkClick} />);
+    const drawerButton: HTMLElement = getByLabelText(buttonToOpenDrawer);
+
+    fireEvent.click(drawerButton);
+
+    const logoLink: HTMLElement = getByRole('link', { name: logoAlt });
+
+    expect(logoLink).toHaveAttribute('href', '/');
+    expect(logoLink).toHaveAttribute('aria-label', logoAlt);
+  });
+
   it('renders nav items', () => {
     const { getByLabelText, getAllByRole } = render(<Drawer handleLinkClick={handleLinkClick} />);
     const drawerButton: HTMLElement = getByLabelText(buttonToOpenDrawer);

--- a/src/test/testing-library/Header.test.tsx
+++ b/src/test/testing-library/Header.test.tsx
@@ -54,6 +54,14 @@ describe('Header component', () => {
     const { getByAltText } = render(<Header />);
     expect(getByAltText(logoAlt)).toBeInTheDocument();
   });
+
+  it('renders logo link pointing to home with aria-label', () => {
+    const { getByRole } = render(<Header />);
+    const logoLink: HTMLElement = getByRole('link', { name: logoAlt });
+
+    expect(logoLink).toHaveAttribute('href', '/');
+    expect(logoLink).toHaveAttribute('aria-label', logoAlt);
+  });
 });
 
 jest.mock('../../features/landing/helpers/scrollToAnchor', () => ({

--- a/src/test/visual/visualComparison.spec.ts
+++ b/src/test/visual/visualComparison.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 import { test, expect } from '@playwright/test';
 
 import { screenSizes, timeoutDuration } from './constants';

--- a/src/test/visual/visualComparison.spec.ts
+++ b/src/test/visual/visualComparison.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 import { test, expect } from '@playwright/test';
 
 import { screenSizes, timeoutDuration } from './constants';
@@ -6,7 +5,7 @@ import { screenSizes, timeoutDuration } from './constants';
 const currentLanguage: string = process.env.NEXT_PUBLIC_MAIN_LANGUAGE as string;
 
 test.describe('Visual Tests', () => {
-  for (const screen of screenSizes) {
+  screenSizes.forEach(screen => {
     test(`${screen.name} test`, async ({ page }) => {
       await page.goto('/');
 
@@ -28,5 +27,5 @@ test.describe('Visual Tests', () => {
         fullPage: true,
       });
     });
-  }
+  });
 });

--- a/src/test/visual/visualNotificationError.spec.ts
+++ b/src/test/visual/visualNotificationError.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 import { test, Locator, expect, Route } from '@playwright/test';
 
 import { currentLanguage, placeholders, screenSizes } from '@/test/visual/constants';
@@ -12,7 +11,7 @@ const serverErrorResponse: ErrorResponseProps = {
 };
 
 test.describe('Form Submission Server Error Test', () => {
-  for (const screen of screenSizes) {
+  screenSizes.forEach(screen => {
     test(`Server error notification - ${screen.name}`, async ({ page }) => {
       await page.goto('/');
 
@@ -55,5 +54,5 @@ test.describe('Form Submission Server Error Test', () => {
 
       await page.unroute('**/graphql', routeHandler);
     });
-  }
+  });
 });

--- a/src/test/visual/visualNotificationError.spec.ts
+++ b/src/test/visual/visualNotificationError.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 import { test, Locator, expect, Route } from '@playwright/test';
 
 import { currentLanguage, placeholders, screenSizes } from '@/test/visual/constants';

--- a/src/test/visual/visualNotificationSuccess.spec.ts
+++ b/src/test/visual/visualNotificationSuccess.spec.ts
@@ -1,11 +1,10 @@
-/* eslint-disable no-restricted-syntax */
 import { test, expect, Locator, Route } from '@playwright/test';
 
 import { screenSizes, currentLanguage, placeholders } from './constants';
 import { successResponse } from './graphqlMocks';
 
 test.describe('Form Submission Visual Test', () => {
-  for (const screen of screenSizes) {
+  screenSizes.forEach(screen => {
     test(`Success notification - ${screen.name}`, async ({ page }) => {
       await page.goto('/');
 
@@ -47,5 +46,5 @@ test.describe('Form Submission Visual Test', () => {
 
       await page.unroute('**/graphql', routeHandler);
     });
-  }
+  });
 });

--- a/src/test/visual/visualNotificationSuccess.spec.ts
+++ b/src/test/visual/visualNotificationSuccess.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 import { test, expect, Locator, Route } from '@playwright/test';
 
 import { screenSizes, currentLanguage, placeholders } from './constants';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - wrap header logo in a Next.js link to `/` with aria label and sizing wrapper
  - make drawer logo a Next.js link to `/` with shared styling
  - add shared logo link styles (alignment, cursor, responsive sizing)
  - add unit tests covering header and drawer logo links
## Related Issue
Add navigation to the homepage when clicking the logo in the navbar

  ## Motivation and Context
  Ensures clicking the navbar logo returns users to the homepage from any page.

  ## How Has This Been Tested?
  - TEST_ENV=client pnpm jest --runTestsByPath src/test/testing-library/Header.test.tsx src/test/testing-library/
  Drawer.test.tsx
    - Tests passed; existing act() warnings from Next/MUI links during user-event clicks and coverage write failed due to
  permission to /coverage (tests still succeeded).

  ## Screenshots (if appropriate):
  N/A

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:
  - [x] My code follows the code style of this project.
  - [x] I have performed a self-review of my code.
  - [ ] I have commented my code, particularly in hard-to-understand areas.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have read the CONTRIBUTING.md document.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.  (Tests pass; coverage write failed due to permissions; see “How Has This Been
  Tested?”.)
  - [ ] New components have been added to Storybook.
  - [x] You have only one commit (if not, squash them into one commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logo now uses client-side navigation to the home page and includes an accessible aria-label in both header and drawer.

* **Style**
  * Added logo link styling (inline-flex alignment, clickable cursor) and fixed logo dimensions; removed responsive breakpoint adjustments.

* **Tests**
  * Added unit, end-to-end, and memory-leak tests verifying logo link, aria-label, navigation behavior, and updated visual test iteration style.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->