### PR TITLE
fix: stabilize swagger network failure assertions

### DIFF
--- a/src/test/e2e/swagger/utils/helpers.ts
+++ b/src/test/e2e/swagger/utils/helpers.ts
@@ -147,24 +147,44 @@ export async function getEndpointCopyButton(endpoint: Locator): Promise<Locator>
   return endpoint.locator('.curl-command .copy-to-clipboard button');
 }
 
-export async function expectErrorOrFailureStatus(getEndpoint: Locator): Promise<void> {
-  const errorElement: Locator = getEndpoint
-    .locator('.response-col_description .renderedMarkdown p')
-    .first();
+async function readFailureState(getEndpoint: Locator): Promise<{
+  combinedErrorText: string;
+  statusText: string | null;
+}> {
+  const responseDescription: Locator = getEndpoint.locator('.response-col_description').first();
   const responseBody: Locator = getEndpoint.locator('.response .highlight-code').first();
   const statusLocator: Locator = getEndpoint.locator('.response .response-col_status').first();
 
-  await expect(errorElement).toBeVisible();
-
-  const errorText: string | null = await errorElement.textContent();
+  const descriptionText: string | null = await responseDescription.textContent().catch(() => null);
   const responseBodyText: string | null = await responseBody.textContent().catch(() => null);
   const statusText: string | null = await statusLocator.textContent().catch(() => null);
-  const combinedErrorText: string = [errorText, responseBodyText]
+  const combinedErrorText: string = [descriptionText, responseBodyText]
     .filter((value): value is string => Boolean(value))
     .join('\n')
     .trim();
 
-  expect(isExpectedFailureState(combinedErrorText, statusText)).toBe(true);
+  return {
+    combinedErrorText,
+    statusText,
+  };
+}
+
+export async function expectErrorOrFailureStatus(getEndpoint: Locator): Promise<void> {
+  const responseSection: Locator = getEndpoint.locator('.responses-wrapper, .responses-inner').first();
+
+  await expect(responseSection).toBeVisible();
+  await expect
+    .poll(
+      async (): Promise<boolean> => {
+        const { combinedErrorText, statusText } = await readFailureState(getEndpoint);
+
+        return isExpectedFailureState(combinedErrorText, statusText);
+      },
+      {
+        timeout: 10000,
+      }
+    )
+    .toBe(true);
 }
 
 export function buildSafeUrl(baseUrl: string, id: string): string {


### PR DESCRIPTION
## Summary
- poll the rendered Swagger response instead of snapshotting it immediately in `expectErrorOrFailureStatus`
- read the full response description/body when deciding whether a network failure was rendered
- stabilize the WebKit negative-path Swagger tests that are currently breaking prod Playwright E2E batches

## Issue
- closes #290

## AWS failure reference
- `ci-cd-website-prod-pipeline` execution `359ab7e6-5a3a-4b72-a4bb-d30997174984`
- failed child build `ci-cd-website-prod-batch-pw-load:38d5e7c6-d11d-4329-86e9-b74543786a51`
