### PR TITLE
docs(#302): require positive, negative, and edge-case test coverage in agents.md

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,139 @@
+# agents.md
+
+This file is the contract for AI coding agents (Claude Code, Codex, GitHub Copilot,
+Cursor, and any other assistant) working in the VilnaCRM website repository. It defines a
+mandatory test-coverage policy and the exact workflow to follow whenever you write or
+update tests.
+
+The stack is Next.js 16, React 19, TypeScript 6, MUI 9 with Emotion, Apollo Client 4 with
+Apollo Server 5, react-hook-form, i18next, and Storybook 10. The package manager is
+`pnpm@10.6.5` and Node `>=20`. The project structure is adapted from bulletproof-react. All
+commands are Makefile targets run from the repository root.
+
+## Mandatory Test-Scenario Coverage Policy
+
+This policy is a hard requirement, not advice. It applies to every AI agent whenever you
+write or update tests — when adding a feature, changing behavior, or fixing a bug. Adding
+only a happy-path test is NOT adequate coverage and does NOT make the work done.
+
+Follow the five steps below in order. Skipping a scenario class or step is allowed ONLY
+with a recorded, concrete justification (see Step 3) — never by silent omission.
+
+### Step 1 — Pick the Right Test Layer
+
+Choose the layer(s) that actually exercise the change; a single change often needs more
+than one. Match the change to the suite and run its verification command.
+
+| Test layer        | Use it for                                 | Command                 |
+| ----------------- | ------------------------------------------ | ----------------------- |
+| Client unit       | Components, hooks, and pure client logic   | `make test-unit-client` |
+| Server unit       | Apollo resolvers and server-side logic     | `make test-unit-server` |
+| End-to-end (e2e)  | User-facing flows end to end (Mockoon API) | `make test-e2e`         |
+| Visual regression | Any change to rendered UI or styling       | `make test-visual`      |
+
+Client unit tests run on Jest with React Testing Library in a jsdom env
+(`TEST_ENV=client`); specs live in `src/test/testing-library/**/*.test.tsx` and
+`src/test/unit/**/*.test.ts`. Server unit tests run on Jest in a node env
+(`TEST_ENV=server`); specs live in `src/test/apollo-server/**/*.test.ts`. E2E and visual
+specs are Playwright across chromium, firefox, and webkit (`src/test/e2e/**/*.spec.ts`,
+`src/test/visual/**/*.spec.ts`); visual snapshots sit in adjacent `*-snapshots/` folders.
+Run both unit layers with `make test-unit-all`.
+
+Add a specialized suite when the change touches its concern: `make test-mutation` (test
+strength), `make test-bats` (Makefile and CI shell flows), `make test-memory-leak` (leaks),
+`make load-tests` (traffic, K6), and `make lighthouse-desktop` / `make lighthouse-mobile`
+(performance, accessibility, best practices).
+
+### Step 2 — Cover Every Applicable Scenario Class
+
+For each layer you touch, cover all three scenario classes that apply to the change.
+Positive coverage on its own is never enough.
+
+1. Positive / happy path — valid input and expected success behavior.
+2. Negative / invalid / failure path — invalid input, validation failures, and error,
+   loading, timeout, and retry handling.
+3. Boundary / edge cases — empty, null, and missing-data states, plus boundary values and
+   off-by-one behavior.
+
+Walk this checklist and add coverage for every item the change can reach.
+
+- [ ] Valid input and expected success behavior
+- [ ] Invalid input and validation failures
+- [ ] Empty, null, or missing data states
+- [ ] Loading, retry, timeout, and error states
+- [ ] Permission, auth, and role-based behavior
+- [ ] Boundary values and off-by-one conditions
+- [ ] Locale, formatting, and translation-sensitive behavior
+- [ ] Responsive and mobile differences for user-facing flows
+- [ ] Accessibility-visible behavior when UI interactions change
+- [ ] Regression protection for previously fixed bugs (see Step 4)
+
+Existing suites already model this: validation suites such as
+`src/test/unit/email-validation.test.ts` cover valid, invalid, and empty-string cases in
+one place. Match that depth.
+
+### Step 3 — Document Any Skipped Scenario Class
+
+If a scenario class or checklist item genuinely does not apply, record it explicitly with a
+concrete reason — in the test file (as a comment), the pull request description, or your
+task summary. Use the `Not applicable: <reason>` convention. A bare "not applicable" with
+no reason, or silent omission, does not satisfy this policy.
+
+Examples of acceptable justifications:
+
+- `Boundary / edge — Not applicable: presentational component with no inputs or branches.`
+- `Permission / auth — Not applicable: static marketing footer, no authenticated state.`
+- `Loading / error — Not applicable: pure synchronous helper with no async boundary.`
+
+### Step 4 — Regression Coverage Is Mandatory for Bug Fixes
+
+When you fix a bug, add a regression test that fails before your fix and passes after it.
+This is mandatory unless there is a concrete, recorded reason a test cannot reasonably be
+added (for example, the defect lives in third-party infrastructure you do not control).
+Document that reason as in Step 3, and cover the previously broken scenario in the layer
+that best reproduces it (usually client or server unit, sometimes e2e or visual).
+
+### Step 5 — Verify Before Calling Test Work Done
+
+Test work is not done until the relevant verification commands have actually been run and
+pass. Run the layer commands you touched, then the project lint gate.
+
+```bash
+make format                  # Prettier formatting (run before lint)
+CI=1 make test-unit-client   # Client unit suite (jsdom)
+CI=1 make test-unit-server   # Server unit suite (node)
+make test-e2e                # User-facing flows (for UI or behavior changes)
+make test-visual             # Visual regression (for UI or styling changes)
+make lint                    # Full gate: ESLint, TypeScript, and markdownlint
+```
+
+Run only the suites the change affects, but never skip a suite that does apply. Any unit
+command runs locally WITHOUT Docker when prefixed with `CI=1` (for example,
+`CI=1 make test-unit-all`). If a deliberate, reviewed UI change makes visual baselines
+stale, regenerate them with `make test-visual-update` and review the diff before committing.
+
+## Behavior-First Assertions
+
+Prefer meaningful behavior assertions over shallow rendering or snapshot-only coverage.
+
+- Query the way a user perceives the UI: `getByRole`, `getByLabelText`, `getByAltText`, and
+  `getByText` rather than implementation details. Use Playwright user-facing locators in
+  e2e specs for the same reason.
+- Assert against localized strings produced by the i18next `t()` function, not hardcoded
+  English, so translation-sensitive behavior stays covered.
+- Use `describe` and `it` blocks, mirroring the existing suites.
+- Treat snapshots and screenshots as a supplement that guards appearance; the load-bearing
+  assertions must check behavior.
+
+## Definition of Done
+
+A change to tests is done only when every statement below is true.
+
+- The relevant layer(s) were identified before writing tests (Step 1).
+- Positive, negative, and edge/boundary cases are present for every applicable class.
+- Every skipped scenario class has a concrete `Not applicable: <reason>` justification.
+- Bug fixes include a regression test that fails before the fix and passes after it.
+- Assertions check user-facing behavior, not implementation details or snapshots alone.
+- Localized text and accessibility-visible behavior are asserted where the UI changed.
+- The relevant test commands above were run and passed, including `make lint`.
+- Commits follow Conventional Commits.


### PR DESCRIPTION
## Summary

Adds a root-level `agents.md` so AI agents can no longer treat a single happy-path test as
adequate coverage. It defines a clearly labeled, mandatory **Test-Scenario Coverage Policy**
that requires positive, negative, and edge-case coverage whenever tests are written or
updated, and wires in the repo's exact verification commands.

Closes #302.

## What changed (`agents.md` only — docs)

New root `agents.md` with a five-step **Mandatory Test-Scenario Coverage Policy**:

1. **Pick the right test layer** — a table mapping change → suite → command for the four core
   layers (client unit, server unit, e2e, visual), plus specialized suites (`make test-mutation`,
   `make test-bats`, `make test-memory-leak`, `make load-tests`, `make lighthouse-desktop` /
   `make lighthouse-mobile`).
2. **Cover every applicable scenario class** — positive / happy, negative / invalid / failure,
   and boundary / edge — backed by a 10-item checklist covering valid/invalid input,
   empty/null/missing data, loading/retry/timeout/error, permission/auth/role, boundary and
   off-by-one, locale/i18n, responsive/mobile, accessibility-visible behavior, and regressions.
3. **Document any skipped scenario class** with a concrete `Not applicable: <reason>`
   (bare "not applicable" or silent omission is rejected).
4. **Regression coverage is mandatory for bug fixes** — a test that fails before the fix and
   passes after, unless a concrete recorded reason prevents it.
5. **Verify before calling test work done** — run the relevant `make` targets and `make lint`.

It also adds a **Behavior-First Assertions** section (prefer user-facing queries and i18next
`t()` over snapshot/shallow-render-only coverage) and a **Definition of Done** checklist.

The conventions intentionally mirror the CRM repo's policy (VilnaCRM-Org/crm#99) — same
`Not applicable: <reason>` convention and regression-as-mandatory-step — adapted to this
repo's actual commands (pnpm/Jest/Playwright; no integration layer).

## Acceptance criteria mapping

- **A root `agents.md` exists** → new file at repo root.
- **Clearly labeled mandatory policy** → `## Mandatory Test-Scenario Coverage Policy`.
- **Positive/negative/edge explicitly required** → Step 2 (three classes + 10-item checklist).
- **Repo-specific client/server/e2e/visual commands** → Step 1 table + Step 5 gate; every
  `make` target verified against the `Makefile`.
- **Explicit justification when a category is skipped** → Step 3 (`Not applicable: <reason>`).

## Verification

- `make lint-md` → pass (exit 0) — the exact command CI's lint runs via `make lint`.
- `prettier --check agents.md` → clean (matches the pre-commit `make format` step).
- All lines ≤ 100 chars (markdownlint MD013); every fence is ` ```bash ` (MD040); single H1;
  no raw HTML; no duplicate headings.
- Docs-only change — no source/UI/HTML/CSS touched, so accessibility review is not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a root-level `agents.md` that makes positive, negative, and edge-case test coverage mandatory and maps changes to the right test layer and `make` commands. Aligns with #302 by enforcing skip-justification and regression tests for bug fixes.

- **New Features**
  - Five-step Test-Scenario Coverage Policy tying changes to suites: client unit (`make test-unit-client`), server unit (`make test-unit-server`), e2e (`make test-e2e`), visual (`make test-visual`), plus specialized suites (`make test-mutation`, `make test-bats`, `make test-memory-leak`, `make load-tests`, `make lighthouse-desktop`/`make lighthouse-mobile`).
  - Require positive, negative, and boundary coverage; 10-item checklist; any skipped item must note `Not applicable: <reason>`.
  - Bug fixes must include a regression test.
  - Add verification commands before calling tests done: `make format`, unit suites (with `CI=1`), e2e/visual as needed, and `make lint`; include visual snapshot update flow.
  - Guidance on behavior-first assertions (prefer user-facing queries and `i18next` `t()`), plus a Definition of Done.

<sup>Written for commit f57df4e588803a1d918da357ffaec974f41712ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

