### PR TITLE
ci(#316): parallelize PR pipeline with concurrency, matrices, caching, and mutation sharding

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -5,9 +5,20 @@ on:
     branches:
       - main
 
+permissions: {}
+
+# Serialize releases per ref without cancelling: aborting an in-flight changelog
+# commit / tag / release mid-run could leave a partial release, so a newer push
+# queues behind the current one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Generate token

--- a/.github/workflows/bats-testing.yml
+++ b/.github/workflows/bats-testing.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bats:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,38 +5,47 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codecov:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
-      - name: Cache pnpm dependencies
-        id: cache-pnpm-dependencies
-        uses: actions/cache@v4.2.3
+      - name: Cache pnpm store
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: node_modules
-          key: ${{ runner.os }}-dependencies-node-${{ vars.NODE_VERSION }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-dependencies-node-${{ vars.NODE_VERSION }}-
+            ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-
 
-      - name: Install pnpm
-        run: npm install -g pnpm@10.6.5
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup pnpm and install dependencies
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          pnpm config set store-dir ~/.pnpm-store
+          pnpm install --frozen-lockfile
 
       - name: Run unit tests
         run: make test-unit-all
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Keep `corepack prepare` non-interactive if it has to fetch pnpm.
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-cruiser.yml
+++ b/.github/workflows/dependency-cruiser.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-cruiser:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,13 @@ permissions:
   id-token: write
   contents: read
 
+# Serialize deploys per ref without cancelling: aborting an in-flight production
+# CodePipeline trigger mid-run is unsafe, so a newer push queues behind the
+# current one rather than superseding it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -4,21 +4,36 @@ on:
   pull_request:
     branches:
       - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Run Playwright tests
         run: make test-e2e
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: playwright-report-${{ github.run_id }}-${{ github.run_attempt }}
+          name: playwright-report-e2e-${{ github.run_id }}-${{ github.run_attempt }}
           path: playwright-report/
           retention-days: 14

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -13,9 +13,21 @@ concurrency:
 
 jobs:
   test:
+    # The Playwright config pins workers: 1 in CI (Docker cross-container
+    # stability), so the whole suite otherwise runs serially in one job. Instead
+    # of raising the worker count, each runner takes an independent, balanced
+    # slice of the suite via Playwright --shard=<index>/<total>. Bump shardIndex
+    # (and shardTotal in lock-step) to add parallelism; each cell boots its own
+    # prod stack and is fully independent.
+    name: e2e shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -27,13 +39,16 @@ jobs:
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
-      - name: Run Playwright tests
-        run: make test-e2e
+      - name: Run Playwright shard
+        env:
+          SHARD_INDEX: ${{ matrix.shardIndex }}
+          SHARD_TOTAL: ${{ matrix.shardTotal }}
+        run: make test-e2e-shard E2E_SHARD_INDEX="$SHARD_INDEX" E2E_SHARD_TOTAL="$SHARD_TOTAL"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: playwright-report-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+          name: playwright-report-e2e-shard-${{ matrix.shardIndex }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: playwright-report/
           retention-days: 14

--- a/.github/workflows/image-optimization.yml
+++ b/.github/workflows/image-optimization.yml
@@ -10,9 +10,12 @@ on:
 
 permissions: {}
 
+# calibreapp/image-actions commits optimized images back to the PR branch and
+# holds contents: write, so cancelling mid-run could leave a partial commit — a
+# newer push queues behind the current one rather than superseding it.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/image-optimization.yml
+++ b/.github/workflows/image-optimization.yml
@@ -1,4 +1,5 @@
 name: Image optimization
+
 on:
   pull_request:
     paths:
@@ -6,17 +7,29 @@ on:
       - '**.jpeg'
       - '**.png'
       - '**.webp'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event.pull_request.head.repo.full_name == github.repository
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Compress Images
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@9d037c06280028c110ff61c433ad4dc7d33c3c43 # v1.5.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           ignorePaths: 'src/test/**'

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -5,28 +5,42 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   load-testing:
+    # Each K6 scenario is an independent matrix cell (its own runner), so the
+    # homepage and Swagger suites run in parallel instead of one after another.
+    name: ${{ matrix.label }} load testing
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - make_cmd: load-tests
+          - make_cmd: test-load
             label: homepage
-          - make_cmd: load-tests-swagger
+          - make_cmd: test-load-swagger
             label: swagger
-
-    name: ${{ matrix.label }} load testing
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Run ${{ matrix.label }} target
-        run: make ${{ matrix.make_cmd }}
+        env:
+          MAKE_CMD: ${{ matrix.make_cmd }}
+        run: make "$MAKE_CMD"

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -4,15 +4,26 @@ on:
   pull_request:
     branches:
       - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   memory-leak-testing:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
 

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -11,6 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Keep `corepack prepare` non-interactive if it has to fetch pnpm.
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+  # Single source of truth for the shard count; keep the shard job's matrix index
+  # list [0 .. TOTAL-1] in lock-step with it.
+  MUTATION_SHARD_TOTAL: '2'
+
 jobs:
   shard:
     name: shard ${{ matrix.index }}
@@ -20,9 +27,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # To change the shard count, keep this list and the merge job's
-        # MUTATION_SHARD_TOTAL in lock-step: index must be [0 .. TOTAL-1]. A
-        # mismatch fails closed at the merge gate's shard-count/index check.
+        # Keep this list in lock-step with the MUTATION_SHARD_TOTAL env above:
+        # index must be [0 .. TOTAL-1]. A mismatch fails closed at the merge
+        # gate's shard-count/index check (and stryker.shard.config.mjs throws on
+        # an out-of-range index).
         index: [0, 1]
 
     steps:
@@ -54,7 +62,7 @@ jobs:
       - name: Run mutation shard
         env:
           SHARD_INDEX: ${{ matrix.index }}
-        run: make test-mutation-shard MUTATION_SHARD_INDEX="$SHARD_INDEX" MUTATION_SHARD_TOTAL=2
+        run: make test-mutation-shard MUTATION_SHARD_INDEX="$SHARD_INDEX" MUTATION_SHARD_TOTAL="$MUTATION_SHARD_TOTAL"
 
       - name: Upload shard report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -117,4 +125,4 @@ jobs:
           merge-multiple: true
 
       - name: Merge reports and enforce mutation-score gate
-        run: make merge-mutation-reports MUTATION_SHARD_TOTAL=2
+        run: make merge-mutation-reports MUTATION_SHARD_TOTAL="$MUTATION_SHARD_TOTAL"

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -5,22 +5,39 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  mutation-testing:
+  shard:
+    name: shard ${{ matrix.index }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # To change the shard count, keep this list and the merge job's
+        # MUTATION_SHARD_TOTAL in lock-step: index must be [0 .. TOTAL-1]. A
+        # mismatch fails closed at the merge gate's shard-count/index check.
+        index: [0, 1]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
-
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -30,9 +47,74 @@ jobs:
       - name: Setup pnpm and install dependencies
         run: |
           corepack enable
-          corepack prepare $(node -p "require('./package.json').packageManager") --activate
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
           pnpm config set store-dir ~/.pnpm-store
           pnpm install --frozen-lockfile
 
-      - name: Run mutation testing
-        run: make test-mutation
+      - name: Run mutation shard
+        env:
+          SHARD_INDEX: ${{ matrix.index }}
+        run: make test-mutation-shard MUTATION_SHARD_INDEX="$SHARD_INDEX" MUTATION_SHARD_TOTAL=2
+
+      - name: Upload shard report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mutation-shard-${{ matrix.index }}
+          path: reports/mutation/mutation-shard-${{ matrix.index }}.json
+          retention-days: 7
+          if-no-files-found: error
+
+  merge:
+    name: merge and enforce gate
+    needs: shard
+    # Run even when a shard failed so the gate fails CLOSED. Without this the job
+    # would be SKIPPED on shard failure, and branch protection treats a skipped
+    # required check as passing — silently bypassing the mutation gate.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+
+      - name: Fail if any mutation shard did not succeed
+        if: needs.shard.result != 'success'
+        env:
+          SHARD_RESULT: ${{ needs.shard.result }}
+        run: |
+          echo "::error::Mutation shards did not all succeed (result=$SHARD_RESULT); failing the gate."
+          exit 1
+
+      - name: Cache pnpm store
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-
+
+      - name: Setup pnpm and install dependencies
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          pnpm config set store-dir ~/.pnpm-store
+          pnpm install --frozen-lockfile
+
+      - name: Download shard reports
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: mutation-shard-*
+          path: reports/mutation
+          merge-multiple: true
+
+      - name: Merge reports and enforce mutation-score gate
+        run: make merge-mutation-reports MUTATION_SHARD_TOTAL=2

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Keep `corepack prepare` non-interactive if it has to fetch pnpm.
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+
 jobs:
   performance:
     # Desktop and mobile Lighthouse used to run back-to-back in one job, each

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -5,39 +5,53 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   performance:
+    # Desktop and mobile Lighthouse used to run back-to-back in one job, each
+    # booting and building the app; they are now independent matrix cells that
+    # run in parallel, cutting the job's wall-clock roughly in half.
+    name: lighthouse ${{ matrix.formFactor }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        formFactor: [desktop, mobile]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
-      - name: Cache pnpm dependencies
-        id: cache-pnpm-dependencies
-        uses: actions/cache@v4.2.3
+      - name: Cache pnpm store
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: node_modules
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-dependencies-
+            ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - name: Setup pnpm and install dependencies
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          pnpm config set store-dir ~/.pnpm-store
+          pnpm install --frozen-lockfile
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        if: |
-          steps.cache-pnpm-dependencies.outputs.cache-hit != 'true' ||
-          false
-
-      - name: Run desktop performance test
-        run: make lighthouse-desktop
-
-      - name: Run mobile performance test
-        run: make lighthouse-mobile
+      - name: Run ${{ matrix.formFactor }} performance test
+        env:
+          FORM_FACTOR: ${{ matrix.formFactor }}
+        run: make "lighthouse-$FORM_FACTOR"

--- a/.github/workflows/sandbox-creating.yml
+++ b/.github/workflows/sandbox-creating.yml
@@ -15,6 +15,12 @@ permissions:
   contents: read
   pull-requests: read
 
+# Serialize sandbox provisioning per branch/PR without cancelling: aborting an
+# in-flight AWS pipeline trigger mid-run is unsafe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check-tokens:
     runs-on: ubuntu-latest

--- a/.github/workflows/sandbox-deleting.yml
+++ b/.github/workflows/sandbox-deleting.yml
@@ -14,6 +14,12 @@ permissions:
   contents: read
   pull-requests: read
 
+# Serialize sandbox teardown per branch/PR without cancelling: aborting an
+# in-flight AWS pipeline trigger mid-run is unsafe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   trigger-sandbox-deletion-pipeline:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
@@ -21,25 +27,27 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Cache CodeQL databases
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: ${{ runner.workspace }}/codeql_databases
+          path: ${{ github.workspace }}/codeql_databases
           key: ${{ runner.os }}-codeql-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-codeql-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -43,6 +43,9 @@ jobs:
         uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: ${{ matrix.language }}
+          # Pin the database directory to the cached path; the action otherwise
+          # defaults to a temp dir the cache step would never hit.
+          db-location: ${{ github.workspace }}/codeql_databases
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3

--- a/.github/workflows/static-testing.yml
+++ b/.github/workflows/static-testing.yml
@@ -34,13 +34,20 @@ jobs:
         id: cache-pnpm-dependencies
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
+          # Node comes from .nvmrc here, so fold it into the key: a Node bump must
+          # invalidate node_modules or a stale native module could be restored.
           path: node_modules
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-dependencies-${{ hashFiles('.nvmrc') }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-dependencies-
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        # Install the exact pnpm pinned in package.json's packageManager field
+        # (not the latest global) so lockfile resolution matches the other jobs.
+        # Corepack is avoided: the .nvmrc-pinned Node (22.12) ships a corepack
+        # whose signing keys can't verify the registry ("Cannot find matching
+        # keyid"). Mirrors dependency-cruiser.yml, the sibling .nvmrc job.
+        run: npm install -g "$(node -p "require('./package.json').packageManager.split('+')[0]")"
 
       - name: Install dependencies
         run: make install

--- a/.github/workflows/static-testing.yml
+++ b/.github/workflows/static-testing.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static:
     runs-on: ubuntu-latest
@@ -14,10 +18,12 @@ jobs:
       CI: 1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           # Use the repo's pinned LTS (.nvmrc). dependency-cruiser, run via
           # `make lint`, supports LTS Node only (^20.12 || ^22 || >=24) and
@@ -26,7 +32,7 @@ jobs:
 
       - name: Cache pnpm dependencies
         id: cache-pnpm-dependencies
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: node_modules
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -38,9 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: make install
-        if: |
-          steps.cache-pnpm-dependencies.outputs.cache-hit != 'true' ||
-          steps.cache-pnpm-packages.outputs.cache-hit != 'true'
+        if: steps.cache-pnpm-dependencies.outputs.cache-hit != 'true'
 
       - name: Run all linters
         run: make lint

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -1,34 +1,46 @@
 name: unit testing
+
 on:
   pull_request:
     branches:
       - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
-      - name: Cache pnpm dependencies
-        id: cache-pnpm-dependencies
-        uses: actions/cache@v4.2.3
+      - name: Cache pnpm store
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: node_modules
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-dependencies-
+            ${{ runner.os }}-pnpm-node-${{ vars.NODE_VERSION }}-
 
-      - name: Install pnpm
-        run: npm install -g pnpm@10.6.5
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup pnpm and install dependencies
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          pnpm config set store-dir ~/.pnpm-store
+          pnpm install --frozen-lockfile
 
       - name: Run unit tests
         run: make test-unit-all

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Keep `corepack prepare` non-interactive if it has to fetch pnpm.
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -5,25 +5,35 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   visual-test:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Run visual tests
         run: make test-visual
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-visual-${{ github.run_id }}-${{ github.run_attempt }}
           path: playwright-report/
           retention-days: 30

--- a/.github/workflows/yaml-formater.yml
+++ b/.github/workflows/yaml-formater.yml
@@ -5,8 +5,19 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   yamlfmt:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: norwd/fmtya@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: norwd/fmtya@11c4eb4d55f8a465564cbef9aabb3e149d4a6247 # v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,28 @@ the [`complexity-management`](.claude/skills/complexity-management/SKILL.md) ski
 refactoring moves (extract helper, lookup map, typed options object, split file, consolidate
 exits).
 
+## Continuous Integration (parallel PR pipeline)
+
+Each PR check is its own workflow on its own runner, so they run in parallel and a PR is
+gated by the slowest single job, not their sum (issue #316). The layout is
+orchestration-only — every check still runs on every PR at the same thresholds; nothing is
+tiered off, weakened, or removed.
+
+- **Concurrency.** Every workflow sets a `concurrency` group keyed on the PR/ref. PR checks
+  use `cancel-in-progress: true` (a new push cancels the superseded run); the deploy,
+  release, and sandbox workflows use `false` so a production trigger is never aborted
+  mid-run.
+- **Caching.** Node jobs restore the pnpm store (`~/.pnpm-store`, keyed on the Node version
+  and `pnpm-lock.yaml`).
+- **Matrices.** Lighthouse runs `desktop`/`mobile` in parallel, the K6 load suites run in
+  parallel, and mutation testing runs as a shard matrix plus a merge gate.
+- **Mutation sharding.** `make test-mutation-shard` (with `MUTATION_SHARD_INDEX` /
+  `MUTATION_SHARD_TOTAL`) writes a per-shard report (`stryker.shard.config.mjs`, with
+  `break` disabled); `make merge-mutation-reports` unions the shards and re-enforces the
+  exact `break` from `stryker.config.mjs` (`scripts/ci/merge-mutation-reports.ts`). The
+  split is a total partition, so the merged score equals an unsharded run and the merge job
+  fails closed.
+
 ## Architecture
 
 The codebase follows a bulletproof-react, feature-based layout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,9 @@ tiered off, weakened, or removed.
   mid-run.
 - **Caching.** Node jobs restore the pnpm store (`~/.pnpm-store`, keyed on the Node version
   and `pnpm-lock.yaml`).
-- **Matrices.** Lighthouse runs `desktop`/`mobile` in parallel, the K6 load suites run in
-  parallel, and mutation testing runs as a shard matrix plus a merge gate.
+- **Matrices.** The Playwright e2e suite splits across a `--shard` matrix
+  (`test-e2e-shard`), Lighthouse runs `desktop`/`mobile` in parallel, the K6 load suites run
+  in parallel, and mutation testing runs as a shard matrix plus a merge gate.
 - **Mutation sharding.** `make test-mutation-shard` (with `MUTATION_SHARD_INDEX` /
   `MUTATION_SHARD_TOTAL`) writes a per-shard report (`stryker.shard.config.mjs`, with
   `break` disabled); `make merge-mutation-reports` unions the shards and re-enforces the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,45 @@ locally with the CI orchestration targets:
 When you add a new orchestration target, keep
 `tests/bats/make-target-coverage.tsv` in sync as described above.
 
+#### How the PR pipeline runs in parallel
+
+Every check on a pull request is its own workflow on its own runner, so GitHub
+runs them all in parallel — the PR is only as slow as the slowest single job,
+not the sum. This is an orchestration-only layout: the same checks run on every
+PR at the same thresholds; nothing is moved to a nightly tier, weakened, or
+removed.
+
+- **Concurrency.** Every workflow declares a `concurrency` group keyed on the PR
+  (or ref). PR checks set `cancel-in-progress: true`, so a new push cancels the
+  superseded run instead of letting its slow jobs run to completion. The deploy,
+  release, and sandbox workflows use `cancel-in-progress: false` — a production
+  trigger must never be aborted mid-run, so newer pushes queue behind the
+  current one.
+- **Caching.** Node jobs restore the pnpm store (`~/.pnpm-store`, keyed on the
+  Node version and `pnpm-lock.yaml`) so installs are warm instead of cold.
+- **Matrices instead of serial steps.** Lighthouse runs `desktop` and `mobile`
+  as parallel matrix cells, the K6 load suites (homepage, Swagger) run as
+  parallel cells, and mutation testing runs as a shard matrix (see below).
+
+#### Mutation testing runs sharded
+
+Mutation testing runs as a deterministic shard matrix plus a merge gate:
+
+- Each `shard` cell runs `make test-mutation-shard` (with `MUTATION_SHARD_INDEX`
+  and `MUTATION_SHARD_TOTAL`), which slices the `mutate` list from
+  `stryker.config.mjs` (via `stryker.shard.config.mjs`) and writes
+  `reports/mutation/mutation-shard-<i>.json` with `break` disabled.
+- The `merge` job runs `make merge-mutation-reports` (with `MUTATION_SHARD_TOTAL`),
+  which unions the per-shard reports and re-enforces the **exact** `break`
+  threshold read from `stryker.config.mjs`
+  ([`scripts/ci/merge-mutation-reports.ts`](scripts/ci/merge-mutation-reports.ts),
+  unit-tested in `src/test/unit/mutation-report.test.ts`).
+
+The round-robin split is a total partition of `mutate`, so the union equals the
+full list and the sharded score is identical to an unsharded run — the gate is
+preserved, never relaxed. The merge job runs even when a shard fails, so the
+gate fails closed rather than passing vacuously.
+
 #### Dockerfile build performance
 
 If your change touches a `Dockerfile` (or the gate's own config), a CI gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,9 +105,11 @@ removed.
   current one.
 - **Caching.** Node jobs restore the pnpm store (`~/.pnpm-store`, keyed on the
   Node version and `pnpm-lock.yaml`) so installs are warm instead of cold.
-- **Matrices instead of serial steps.** Lighthouse runs `desktop` and `mobile`
-  as parallel matrix cells, the K6 load suites (homepage, Swagger) run as
-  parallel cells, and mutation testing runs as a shard matrix (see below).
+- **Matrices instead of serial steps.** The Playwright e2e suite splits across a
+  Playwright `--shard` matrix (one balanced slice of the ~340 test runs per
+  runner), Lighthouse runs `desktop` and `mobile` as parallel cells, the K6 load
+  suites (homepage, Swagger) run as parallel cells, and mutation testing runs as
+  a shard matrix (see below).
 
 #### Mutation testing runs sharded
 

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,12 @@ MARKDOWNLINT_BIN            = $(PNPM_EXEC) ./node_modules/.bin/markdownlint
 
 run-visual                  = $(PLAYWRIGHT_TEST) "$(PLAYWRIGHT_BIN) test $(TEST_DIR_VISUAL)"
 run-e2e                     = $(PLAYWRIGHT_TEST) "$(PLAYWRIGHT_BIN) test $(TEST_DIR_E2E)"
+# E2E sharding: the e2e workflow matrix runs one shard per runner via Playwright
+# --shard=<index>/<total>. Defaults to 1/1 (the whole suite), so a bare
+# `make test-e2e-shard` behaves exactly like `make test-e2e`.
+E2E_SHARD_INDEX             ?= 1
+E2E_SHARD_TOTAL             ?= 1
+run-e2e-shard               = $(PLAYWRIGHT_TEST) "$(PLAYWRIGHT_BIN) test $(TEST_DIR_E2E) --shard=$(E2E_SHARD_INDEX)/$(E2E_SHARD_TOTAL)"
 playwright-test             = $(PLAYWRIGHT_DOCKER_CMD) $(PLAYWRIGHT_BIN) test
 
 help:
@@ -306,6 +312,9 @@ storybook-build: ## Build Storybook UI.
 
 test-e2e: start-prod  ## Start production and run E2E tests (Playwright)
 	$(run-e2e)
+
+test-e2e-shard: start-prod ## Start production and run one E2E shard (E2E_SHARD_INDEX of E2E_SHARD_TOTAL; used by the e2e workflow matrix)
+	$(run-e2e-shard)
 
 test-e2e-ui: start-prod ## Start the production environment and run E2E tests with the UI available at $(UI_MODE_URL)
 	@echo "🚀 Starting Playwright UI tests..."

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ TEST_DIR_E2E                = $(TEST_DIR_BASE)/e2e
 TEST_DIR_VISUAL             = $(TEST_DIR_BASE)/visual
 
 STRYKER_CMD                 = pnpm exec stryker run
+STRYKER_SHARD_CONFIG        = stryker.shard.config.mjs
+MUTATION_SHARD_TOTAL        ?= 1
+MUTATION_SHARD_INDEX        ?= 0
+MERGE_MUTATION_REPORTS_CMD  = pnpm exec tsx scripts/ci/merge-mutation-reports.ts
 
 SERVE_CMD                   = --collect.startServerCommand="$(SERVE_BIN) -l $(NEXT_PUBLIC_PROD_PORT) out" \
                               --collect.startServerReadyPattern="Accepting connections"
@@ -376,7 +380,8 @@ ci-test-integration: ## Run integration tests directly assuming deps are install
 	ci-test-mutation ci-mutation ci-prod-setup ci-test-e2e ci-test-visual \
 	ci-test-memory-leak ci-test-load ci-test-lighthouse-desktop \
 	ci-test-lighthouse-mobile ci-test-prod ensure-dev start-prod-clean \
-	test-load test-load-swagger pr-comments
+	test-load test-load-swagger test-mutation-shard merge-mutation-reports \
+	pr-comments
 
 ci-setup: create-network ## Prepare the shared dev environment for CI-oriented checks
 	$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) up $(CI_SETUP_UP_FLAGS) dev && $(MAKE) wait-for-dev
@@ -481,6 +486,13 @@ memory-leak-dind: start-prod ## Run Memlab tests in isolated compose project (DI
 
 test-mutation: build ## Run mutation tests using Stryker after building the app
 	$(STRYKER_CMD)
+
+test-mutation-shard: ## Run mutation shard MUTATION_SHARD_INDEX of MUTATION_SHARD_TOTAL (host; assumes deps installed) — writes reports/mutation/mutation-shard-<index>.json with break disabled
+	MUTATION_SHARD_INDEX=$(MUTATION_SHARD_INDEX) MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) \
+		$(STRYKER_CMD) $(STRYKER_SHARD_CONFIG)
+
+merge-mutation-reports: ## Union the per-shard mutation reports and re-enforce the exact Stryker break gate over the whole set (host; assumes deps installed)
+	MUTATION_SHARD_TOTAL=$(MUTATION_SHARD_TOTAL) $(MERGE_MUTATION_REPORTS_CMD)
 
 wait-for-prod-health: ## Wait for the prod container to reach a healthy state.
 	@echo "Waiting for prod container to become healthy (timeout: 60s)..."

--- a/agents.md
+++ b/agents.md
@@ -46,10 +46,11 @@ strength), `make test-bats` (Makefile and CI shell flows), `make test-memory-lea
 
 In CI these suites are fanned out to run in parallel (issue #316): every workflow declares a
 `concurrency` group (PR checks cancel superseded runs; deploy/release/sandbox do not),
-Lighthouse and the K6 load suites run as matrices, and mutation testing runs as a shard
-matrix whose `merge` job re-enforces the **exact** Stryker `break` threshold over the union
-of shards (`make merge-mutation-reports`). The thresholds are unchanged — locally you still
-run the single `make test-mutation`.
+the Playwright e2e suite, Lighthouse, and the K6 load suites run as matrices, and mutation
+testing runs as a shard matrix whose `merge` job re-enforces the **exact** Stryker `break`
+threshold over the union of shards (`make merge-mutation-reports`). The thresholds and the
+test set are unchanged — locally you still run the single `make test-e2e` / `make
+test-mutation`.
 
 ### Step 2 — Cover Every Applicable Scenario Class
 

--- a/agents.md
+++ b/agents.md
@@ -44,6 +44,13 @@ strength), `make test-bats` (Makefile and CI shell flows), `make test-memory-lea
 `make load-tests` (traffic, K6), and `make lighthouse-desktop` / `make lighthouse-mobile`
 (performance, accessibility, best practices).
 
+In CI these suites are fanned out to run in parallel (issue #316): every workflow declares a
+`concurrency` group (PR checks cancel superseded runs; deploy/release/sandbox do not),
+Lighthouse and the K6 load suites run as matrices, and mutation testing runs as a shard
+matrix whose `merge` job re-enforces the **exact** Stryker `break` threshold over the union
+of shards (`make merge-mutation-reports`). The thresholds are unchanged — locally you still
+run the single `make test-mutation`.
+
 ### Step 2 — Cover Every Applicable Scenario Class
 
 For each layer you touch, cover all three scenario classes that apply to the change.

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "terser-webpack-plugin": "^5.6.1",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "wait-on": "^9.0.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 10.55.0(react@19.2.6)
       '@storybook/nextjs':
         specifier: ^10.4.1
-        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(babel-plugin-macros@3.1.0)(esbuild@0.27.7)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(type-fest@4.41.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(type-fest@4.41.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -227,7 +227,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+        version: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
       jest-environment-jsdom:
         specifier: ^30.4.1
         version: 30.4.1
@@ -254,13 +254,16 @@ importers:
         version: 14.2.6
       terser-webpack-plugin:
         specifier: ^5.6.1
-        version: 5.6.1(esbuild@0.27.7)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+        version: 5.6.1(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)))(typescript@6.0.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1241,8 +1244,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1253,8 +1268,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1265,8 +1292,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1277,8 +1316,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1289,8 +1340,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1301,8 +1364,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1313,8 +1388,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1325,8 +1412,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1337,8 +1436,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1349,8 +1460,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1361,8 +1484,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1373,8 +1508,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1385,8 +1532,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -4733,6 +4892,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8169,6 +8333,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
@@ -9912,79 +10081,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -10361,7 +10608,7 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))':
+  '@jest/core@30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
@@ -10377,7 +10624,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -11196,7 +11443,7 @@ snapshots:
     dependencies:
       playwright: 1.57.0
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.49.0
@@ -11206,7 +11453,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     optionalDependencies:
       type-fest: 4.41.0
       webpack-hot-middleware: 2.26.1
@@ -11435,22 +11682,22 @@ snapshots:
     dependencies:
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/builder-webpack5@10.4.1(esbuild@0.27.7)(postcss@8.5.15)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)':
+  '@storybook/builder-webpack5@10.4.1(esbuild@0.28.1)(postcss@8.5.15)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)':
     dependencies:
       '@storybook/core-webpack': 10.4.1(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 7.1.4(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      css-loader: 7.1.4(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
-      html-webpack-plugin: 5.6.7(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
+      html-webpack-plugin: 5.6.7(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       magic-string: 0.30.21
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      style-loader: 4.0.0(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
-      terser-webpack-plugin: 5.6.1(esbuild@0.27.7)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      style-loader: 4.0.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       ts-dedent: 2.2.0
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
-      webpack-dev-middleware: 6.1.3(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
+      webpack-dev-middleware: 6.1.3(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -11483,7 +11730,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@storybook/nextjs@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(babel-plugin-macros@3.1.0)(esbuild@0.27.7)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(type-fest@4.41.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))':
+  '@storybook/nextjs@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(babel-plugin-macros@3.1.0)(esbuild@0.28.1)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(type-fest@4.41.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
@@ -11498,27 +11745,27 @@ snapshots:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/runtime': 7.29.7
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
-      '@storybook/builder-webpack5': 10.4.1(esbuild@0.27.7)(postcss@8.5.15)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
-      '@storybook/preset-react-webpack': 10.4.1(esbuild@0.27.7)(postcss@8.5.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
+      '@storybook/builder-webpack5': 10.4.1(esbuild@0.28.1)(postcss@8.5.15)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
+      '@storybook/preset-react-webpack': 10.4.1(esbuild@0.28.1)(postcss@8.5.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       '@storybook/react': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
-      css-loader: 6.11.0(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
+      css-loader: 6.11.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       image-size: 2.0.2
       loader-utils: 3.3.1
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.100.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       postcss: 8.5.15
-      postcss-loader: 8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      postcss-loader: 8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 16.0.8(sass@1.100.0)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      sass-loader: 16.0.8(sass@1.100.0)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       semver: 7.8.1
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      style-loader: 3.3.4(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      style-loader: 3.3.4(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       styled-jsx: 5.1.7(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react@19.2.6)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
@@ -11526,7 +11773,7 @@ snapshots:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
       typescript: 6.0.3
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@rspack/core'
@@ -11553,10 +11800,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@10.4.1(esbuild@0.27.7)(postcss@8.5.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)':
+  '@storybook/preset-react-webpack@10.4.1(esbuild@0.28.1)(postcss@8.5.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)':
     dependencies:
       '@storybook/core-webpack': 10.4.1(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       '@types/semver': 7.7.1
       magic-string: 0.30.21
       react: 19.2.6
@@ -11566,7 +11813,7 @@ snapshots:
       semver: 7.8.1
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tsconfig-paths: 4.2.0
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -11585,7 +11832,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
@@ -11595,7 +11842,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       tslib: 2.8.1
       typescript: 6.0.3
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     transitivePeerDependencies:
       - supports-color
 
@@ -12937,12 +13184,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       '@babel/core': 7.29.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   babel-plugin-istanbul@7.0.1:
     dependencies:
@@ -13617,7 +13864,7 @@ snapshots:
 
   csp_evaluator@1.1.5: {}
 
-  css-loader@6.11.0(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  css-loader@6.11.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -13628,9 +13875,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.1
     optionalDependencies:
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
-  css-loader@7.1.4(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  css-loader@7.1.4(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -13641,7 +13888,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.1
     optionalDependencies:
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   css-select@4.3.0:
     dependencies:
@@ -14059,10 +14306,10 @@ snapshots:
 
   es-toolkit@1.47.0: {}
 
-  esbuild-register@3.6.0(esbuild@0.27.7):
+  esbuild-register@3.6.0(esbuild@0.28.1):
     dependencies:
       debug: 4.4.3
-      esbuild: 0.27.7
+      esbuild: 0.28.1
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -14095,6 +14342,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -14649,7 +14925,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@6.0.3)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -14664,7 +14940,7 @@ snapshots:
       semver: 7.8.1
       tapable: 2.3.3
       typescript: 6.0.3
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   form-data@4.0.5:
     dependencies:
@@ -14952,7 +15228,7 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
-  html-webpack-plugin@5.6.7(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  html-webpack-plugin@5.6.7(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -14960,7 +15236,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -15396,15 +15672,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
+  jest-cli@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      '@jest/core': 30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.2
@@ -15415,7 +15691,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
+  jest-config@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
@@ -15442,7 +15718,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.1
-      esbuild-register: 3.6.0(esbuild@0.27.7)
+      esbuild-register: 3.6.0(esbuild@0.28.1)
       ts-node: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -15714,12 +15990,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
+  jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      '@jest/core': 30.4.2(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      jest-cli: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -16482,7 +16758,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -16509,7 +16785,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   node-releases@2.0.46: {}
 
@@ -16875,14 +17151,14 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  postcss-loader@8.2.1(postcss@8.5.15)(typescript@6.0.3)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.7.0
       postcss: 8.5.15
       semver: 7.8.1
     optionalDependencies:
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
 
@@ -17499,12 +17775,12 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.8(sass@1.100.0)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  sass-loader@16.0.8(sass@1.100.0)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.100.0
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   sass@1.100.0:
     dependencies:
@@ -17949,13 +18225,13 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-loader@3.3.4(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  style-loader@3.3.4(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
-  style-loader@4.0.0(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  style-loader@4.0.0(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react@19.2.6):
     dependencies:
@@ -18096,15 +18372,15 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.6.1(esbuild@0.27.7)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.1(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
     optionalDependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       postcss: 8.5.15
 
   terser@5.48.0:
@@ -18229,12 +18505,12 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.27.7)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.2.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.7))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
+      jest: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -18247,7 +18523,7 @@ snapshots:
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       babel-jest: 30.2.0(@babel/core@7.29.7)
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       jest-util: 30.4.1
 
   ts-mixer@6.0.4: {}
@@ -18295,6 +18571,12 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tty-browserify@0.0.1: {}
 
@@ -18593,7 +18875,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@6.1.3(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15)):
+  webpack-dev-middleware@6.1.3(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -18601,7 +18883,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.2(esbuild@0.27.7)(postcss@8.5.15)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.15)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -18613,7 +18895,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15):
+  webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -18635,7 +18917,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(esbuild@0.27.7)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.27.7)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/scripts/ci/merge-mutation-reports.ts
+++ b/scripts/ci/merge-mutation-reports.ts
@@ -1,0 +1,113 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { type MutationReport, scoreReports } from './mutation-report';
+
+const SHARD_FILE = /^mutation-shard-\d+\.json$/;
+
+/** Fixed shard-report directory; never taken from argv so it stays path-injection safe. */
+const REPORTS_DIR = resolve(process.cwd(), 'reports', 'mutation');
+
+/** Read and parse every `mutation-shard-*.json` report in `dir`, sorted by name. */
+function loadShardReports(dir: string): { name: string; report: MutationReport }[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (error) {
+    throw new Error(`Could not read mutation report directory "${dir}": ${String(error)}`);
+  }
+
+  return entries
+    .filter(name => SHARD_FILE.test(name))
+    .sort((a, b) => a.localeCompare(b))
+    .map(name => {
+      const raw = readFileSync(join(dir, name), 'utf8');
+      try {
+        return { name, report: JSON.parse(raw) as MutationReport };
+      } catch (error) {
+        throw new Error(`Mutation report "${name}" is not valid JSON: ${String(error)}`);
+      }
+    });
+}
+
+/** Read the canonical `thresholds.break` from the real Stryker config so it can never drift. */
+async function resolveBreakThreshold(): Promise<number> {
+  const { default: base } = (await import('../../stryker.config.mjs')) as {
+    default: { thresholds?: { break?: number | null } };
+  };
+  const breakThreshold = base.thresholds?.break;
+  if (typeof breakThreshold !== 'number') {
+    throw new TypeError(
+      'stryker.config.mjs has no numeric thresholds.break; refusing to gate without a threshold.'
+    );
+  }
+  return breakThreshold;
+}
+
+/** Merge shard reports, recompute the score, and exit non-zero if below the break gate. */
+async function main(): Promise<void> {
+  const dir = REPORTS_DIR;
+
+  const expectedShards = Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '', 10);
+  if (!Number.isInteger(expectedShards) || expectedShards <= 0) {
+    throw new Error(
+      'MUTATION_SHARD_TOTAL must be a positive integer so the gate can verify every shard.'
+    );
+  }
+
+  const shards = loadShardReports(dir);
+  if (shards.length !== expectedShards) {
+    throw new Error(
+      `Expected ${expectedShards} shard reports but found ${shards.length} (${
+        shards.map(s => s.name).join(', ') || 'none'
+      }). A missing shard must not pass the gate vacuously.`
+    );
+  }
+
+  const seen = new Set(shards.map(s => Number.parseInt(/\d+/.exec(s.name)?.[0] ?? '-1', 10)));
+  for (let i = 0; i < expectedShards; i += 1) {
+    if (!seen.has(i)) {
+      throw new Error(`Mutation shard ${i} of ${expectedShards} is missing from "${dir}".`);
+    }
+  }
+
+  const breakThreshold = await resolveBreakThreshold();
+  const { tally, fileCount, mutationScore } = scoreReports(shards.map(s => s.report));
+
+  if (!Number.isFinite(mutationScore) || tally.valid === 0) {
+    throw new Error(
+      `No valid mutants found across ${shards.length} shard(s) over ${fileCount} file(s); ` +
+        'the mutation run is misconfigured.'
+    );
+  }
+
+  const score = mutationScore.toFixed(2);
+  process.stdout.write(
+    [
+      `Merged ${shards.length} mutation shard(s) over ${fileCount} source file(s):`,
+      `  killed=${tally.killed} timeout=${tally.timeout} ` +
+        `survived=${tally.survived} noCoverage=${tally.noCoverage}`,
+      `  compileError=${tally.compileError} runtimeError=${tally.runtimeError} ` +
+        `ignored=${tally.ignored}`,
+      `  detected=${tally.detected} valid=${tally.valid} mutationScore=${score}%`,
+      '',
+    ].join('\n')
+  );
+
+  if (mutationScore < breakThreshold) {
+    process.stderr.write(
+      `Mutation score ${score}% is below the break threshold ${breakThreshold}%. Gate failed.\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `Mutation score ${score}% meets the break threshold ${breakThreshold}%. Gate passed.\n`
+  );
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/ci/mutation-report.ts
+++ b/scripts/ci/mutation-report.ts
@@ -1,0 +1,105 @@
+/** A single mutant entry in a `mutation-testing-elements` JSON report. */
+export interface ReportMutant {
+  status?: string;
+}
+
+/** A source file entry (the system under test) in a mutation report. */
+export interface ReportFile {
+  mutants?: ReportMutant[];
+}
+
+/** The subset of the `mutation-testing-elements` schema this gate reads. */
+export interface MutationReport {
+  files?: Record<string, ReportFile>;
+}
+
+/** Per-status mutant counts plus the derived detected/undetected/valid totals. */
+export interface StatusTally {
+  killed: number;
+  timeout: number;
+  survived: number;
+  noCoverage: number;
+  compileError: number;
+  runtimeError: number;
+  ignored: number;
+  pending: number;
+  detected: number;
+  undetected: number;
+  valid: number;
+}
+
+/** The merged score over a set of shard reports. */
+export interface ScoreResult {
+  tally: StatusTally;
+  fileCount: number;
+  mutationScore: number;
+}
+
+/** Union the `files` maps of every shard report, keyed by source path (first occurrence wins). */
+export function mergeReportFiles(reports: readonly MutationReport[]): Map<string, ReportMutant[]> {
+  const byFile = new Map<string, ReportMutant[]>();
+  for (const report of reports) {
+    for (const [path, file] of Object.entries(report.files ?? {})) {
+      if (!byFile.has(path)) {
+        byFile.set(path, file?.mutants ?? []);
+      }
+    }
+  }
+  return byFile;
+}
+
+/** Map each Stryker mutant status to its tally counter. */
+const STATUS_TALLY_KEYS = new Map<string, keyof StatusTally>([
+  ['Killed', 'killed'],
+  ['Timeout', 'timeout'],
+  ['Survived', 'survived'],
+  ['NoCoverage', 'noCoverage'],
+  ['CompileError', 'compileError'],
+  ['RuntimeError', 'runtimeError'],
+  ['Ignored', 'ignored'],
+]);
+
+/** Tally mutant statuses across the merged source files and derive detected/undetected/valid. */
+export function tallyMutants(mutantsByFile: ReadonlyMap<string, ReportMutant[]>): StatusTally {
+  const tally: StatusTally = {
+    killed: 0,
+    timeout: 0,
+    survived: 0,
+    noCoverage: 0,
+    compileError: 0,
+    runtimeError: 0,
+    ignored: 0,
+    pending: 0,
+    detected: 0,
+    undetected: 0,
+    valid: 0,
+  };
+
+  for (const mutants of mutantsByFile.values()) {
+    for (const mutant of mutants) {
+      const key = mutant.status === undefined ? undefined : STATUS_TALLY_KEYS.get(mutant.status);
+      if (key === undefined) {
+        tally.pending += 1;
+      } else {
+        tally[key] += 1;
+      }
+    }
+  }
+
+  tally.detected = tally.killed + tally.timeout;
+  tally.undetected = tally.survived + tally.noCoverage;
+  tally.valid = tally.detected + tally.undetected;
+  return tally;
+}
+
+/** Mutation score (`detected / valid * 100`), or `NaN` when there are no valid mutants. */
+export function mutationScore(tally: StatusTally): number {
+  return tally.valid > 0 ? (tally.detected / tally.valid) * 100 : Number.NaN;
+}
+
+/** Merge shard reports and compute the overall mutation score. */
+export function scoreReports(reports: readonly MutationReport[]): ScoreResult {
+  const byFile = mergeReportFiles(reports);
+  const tally = tallyMutants(byFile);
+  return { tally, fileCount: byFile.size, mutationScore: mutationScore(tally) };
+}

--- a/src/test/unit/mutation-report.test.ts
+++ b/src/test/unit/mutation-report.test.ts
@@ -1,0 +1,105 @@
+import {
+  type MutationReport,
+  mergeReportFiles,
+  mutationScore,
+  scoreReports,
+  tallyMutants,
+} from '../../../scripts/ci/mutation-report';
+
+function report(files: Record<string, string[]>): MutationReport {
+  return {
+    files: Object.fromEntries(
+      Object.entries(files).map(([path, statuses]) => [
+        path,
+        { mutants: statuses.map(status => ({ status })) },
+      ])
+    ),
+  };
+}
+
+describe('mutation-report merge gate', () => {
+  describe('mutationScore mirrors Stryker (detected / valid * 100)', () => {
+    it('counts killed and timeout as detected', () => {
+      const tally = tallyMutants(mergeReportFiles([report({ 'a.ts': ['Killed', 'Timeout'] })]));
+      expect(tally.detected).toBe(2);
+      expect(tally.valid).toBe(2);
+      expect(mutationScore(tally)).toBe(100);
+    });
+
+    it('counts survived and noCoverage against the score (undetected, still valid)', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([report({ 'a.ts': ['Killed', 'Killed', 'Survived', 'NoCoverage'] })])
+      );
+      expect(tally.detected).toBe(2);
+      expect(tally.undetected).toBe(2);
+      expect(tally.valid).toBe(4);
+      expect(mutationScore(tally)).toBe(50);
+    });
+
+    it('excludes compile/runtime errors and ignored mutants from valid', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([
+          report({ 'a.ts': ['Killed', 'CompileError', 'RuntimeError', 'Ignored'] }),
+        ])
+      );
+      expect(tally.compileError).toBe(1);
+      expect(tally.runtimeError).toBe(1);
+      expect(tally.ignored).toBe(1);
+      expect(tally.valid).toBe(1);
+      expect(mutationScore(tally)).toBe(100);
+    });
+
+    it('treats Pending and unknown statuses as non-valid', () => {
+      const tally = tallyMutants(
+        mergeReportFiles([report({ 'a.ts': ['Killed', 'Pending', 'Weird'] })])
+      );
+      expect(tally.pending).toBe(2);
+      expect(tally.valid).toBe(1);
+    });
+
+    it('returns NaN when there are no valid mutants', () => {
+      const tally = tallyMutants(mergeReportFiles([report({ 'a.ts': ['Ignored'] })]));
+      expect(tally.valid).toBe(0);
+      expect(Number.isNaN(mutationScore(tally))).toBe(true);
+    });
+  });
+
+  describe('the break boundary is exact', () => {
+    it('scores 80% when 8 of 10 valid mutants are detected', () => {
+      const statuses = [...Array(8).fill('Killed'), 'Survived', 'NoCoverage'];
+      expect(scoreReports([report({ 'a.ts': statuses })]).mutationScore).toBe(80);
+    });
+
+    it('scores below 100% when a single mutant survives (the website break gate)', () => {
+      const statuses = [...Array(9).fill('Killed'), 'Survived'];
+      expect(scoreReports([report({ 'a.ts': statuses })]).mutationScore).toBeCloseTo(90, 10);
+    });
+  });
+
+  describe('merging shard reports', () => {
+    it('unions disjoint files and sums their mutants', () => {
+      const result = scoreReports([
+        report({ 'a.ts': ['Killed', 'Killed'] }),
+        report({ 'b.ts': ['Killed', 'Survived'] }),
+      ]);
+      expect(result.fileCount).toBe(2);
+      expect(result.tally.detected).toBe(3);
+      expect(result.tally.valid).toBe(4);
+      expect(result.mutationScore).toBe(75);
+    });
+
+    it('does not double-count a file that appears in two shards', () => {
+      const duplicate = report({ 'a.ts': ['Killed', 'Survived'] });
+      const result = scoreReports([duplicate, duplicate]);
+      expect(result.fileCount).toBe(1);
+      expect(result.tally.valid).toBe(2);
+      expect(result.mutationScore).toBe(50);
+    });
+
+    it('tolerates shards whose slice matched no source files', () => {
+      const result = scoreReports([{}, report({ 'a.ts': ['Killed'] })]);
+      expect(result.fileCount).toBe(1);
+      expect(result.mutationScore).toBe(100);
+    });
+  });
+});

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -3,6 +3,15 @@ import base from './stryker.config.mjs';
 const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
 const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
 
+// Fail loud on an out-of-range index instead of letting `index % total` wrap and
+// silently collide with another shard — that would produce a plausible (correct
+// shard count) but wrong partition the merge gate could not detect.
+if (index >= total) {
+  throw new Error(
+    `MUTATION_SHARD_INDEX (${index}) must be less than MUTATION_SHARD_TOTAL (${total}).`
+  );
+}
+
 // The base config enumerates the mutated files explicitly (an array, not a
 // glob), so the shard slices that array deterministically. Sorting first makes
 // the partition stable regardless of source order, and the round-robin split
@@ -11,7 +20,7 @@ const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0
 // identical to an unsharded run.
 const sliced = [...base.mutate]
   .sort((a, b) => a.localeCompare(b))
-  .filter((_, i) => i % total === index % total);
+  .filter((_, i) => i % total === index);
 
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 const config = {

--- a/stryker.shard.config.mjs
+++ b/stryker.shard.config.mjs
@@ -1,0 +1,28 @@
+import base from './stryker.config.mjs';
+
+const total = Math.max(1, Number.parseInt(process.env.MUTATION_SHARD_TOTAL ?? '1', 10) || 1);
+const index = Math.max(0, Number.parseInt(process.env.MUTATION_SHARD_INDEX ?? '0', 10) || 0);
+
+// The base config enumerates the mutated files explicitly (an array, not a
+// glob), so the shard slices that array deterministically. Sorting first makes
+// the partition stable regardless of source order, and the round-robin split
+// (`i % total === index`) guarantees the union of every shard equals the full
+// list exactly — no file is dropped or double-counted — so the merged score is
+// identical to an unsharded run.
+const sliced = [...base.mutate]
+  .sort((a, b) => a.localeCompare(b))
+  .filter((_, i) => i % total === index % total);
+
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  ...base,
+  mutate: sliced,
+  // Emit a machine-readable per-shard report the merge job unions; `break: null`
+  // lets an individual shard finish without gating — the merge job re-enforces
+  // the real `thresholds.break` from stryker.config.mjs over the union.
+  reporters: ['json', 'clear-text', 'progress'],
+  jsonReporter: { fileName: `reports/mutation/mutation-shard-${index}.json` },
+  thresholds: { ...base.thresholds, break: null },
+};
+
+export default config;

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -39,6 +39,8 @@ test-bats	ci	.github/workflows/bats-testing.yml	Executed directly by the dedicat
 test-memory-leak	ci	.github/workflows/memory-leak-testing.yml	Executed directly by the memory leak workflow.
 memory-leak-dind	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker Compose commands.
 test-mutation	ci	.github/workflows/mutation-testing.yml	Executed directly by the mutation testing workflow.
+test-mutation-shard	ci	.github/workflows/mutation-testing.yml	Executed directly by the mutation testing shard matrix.
+merge-mutation-reports	ci	.github/workflows/mutation-testing.yml	Executed by the mutation testing merge job to re-enforce the break gate over the shard union.
 wait-for-prod-health	ci	.github/workflows/load-testing.yml	Executed through `make load-tests` and `make load-tests-swagger`, which depend on `wait-for-prod-health`.
 visual-direct	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker and Playwright commands.
 e2e-direct	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker and Playwright commands.

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -25,6 +25,7 @@ husky	bats	tests/bats/makefile_targets.bats	Validated with a stubbed pnpm invoca
 storybook-start	bats	tests/bats/makefile_targets.bats	Validated with a stubbed Storybook binary.
 storybook-build	bats	tests/bats/makefile_targets.bats	Validated with a stubbed Storybook binary.
 test-e2e	ci	.github/workflows/e2e-testing.yml	Executed directly by the Playwright PR workflow.
+test-e2e-shard	ci	.github/workflows/e2e-testing.yml	Executed directly by the e2e testing workflow shard matrix.
 test-e2e-ui	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker and Playwright commands.
 test-visual	ci	.github/workflows/visual-testing.yml	Executed directly by the visual testing workflow.
 test-visual-ui	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker and Playwright commands.


### PR DESCRIPTION
## Summary

Closes #316. Parallelizes the PR pipeline so a PR is gated by the **slowest single job**, not the sum of every heavy job. This is **orchestration + test-runner config only** — no `src/**` changes, no gate weakened or removed. Every check that runs on a PR today still runs on every PR at the same thresholds.

The layout mirrors the CRM sister repo's proven parallel-CI pattern (concurrency + matrices + mutation sharding + hardening).

## What changed

### Concurrency (every workflow)
- Every workflow now declares a `concurrency` group keyed on the PR/ref.
- **PR checks** use `cancel-in-progress: true` — a new push cancels the superseded run instead of letting its slow jobs run to completion (kills the doubled-contention waste on force-push).
- **Deploy / release / sandbox** (`deploy.yml`, `autorelease.yml`, `sandbox-creating.yml`, `sandbox-deleting.yml`) use `cancel-in-progress: false` — aborting an in-flight production trigger mid-run is unsafe, so newer pushes queue behind the current one. This matches CRM and is documented inline.

### Parallelize sequential work into matrices
- `performance-testing.yml`: desktop + mobile Lighthouse now run as a `formFactor: [desktop, mobile]` matrix (were back-to-back in one job).
- `load-testing.yml`: the homepage / Swagger K6 suites run as independent matrix cells.
- `mutation-testing.yml`: a **shard matrix + merge gate** (below).

### Caching
- Node jobs restore the pnpm store (`~/.pnpm-store`, keyed on Node version + `pnpm-lock.yaml`) — the pattern from `mutation-testing.yml`, extended across Node jobs.

### Mutation sharding (forward-looking, gate preserved exactly)
- `shard` matrix runs `make test-mutation-shard MUTATION_SHARD_INDEX=<i> MUTATION_SHARD_TOTAL=<n>` → slices `stryker.config.mjs`'s `mutate` list (`stryker.shard.config.mjs`, `break` disabled) → uploads `reports/mutation/mutation-shard-<i>.json`.
- `merge` job runs `make merge-mutation-reports MUTATION_SHARD_TOTAL=<n>` → unions the per-shard reports and **re-enforces the exact `break` threshold read from `stryker.config.mjs`** (`scripts/ci/merge-mutation-reports.ts`).
- The round-robin split is a **total partition** of `mutate`, so the union equals the full list and the merged score is byte-identical to an unsharded run — the gate is preserved, never relaxed. The merge job runs even when a shard fails (`if: ${{ !cancelled() }}`), so the gate **fails closed** (a skipped required check would otherwise read as passing).
- Ships `scripts/ci/mutation-report.ts` (pure scoring logic) + `scripts/ci/merge-mutation-reports.ts` (CLI) + a fixture unit test (`src/test/unit/mutation-report.test.ts`, runs in the existing client + server unit suites). `tsx` is added as the host TS runner (CRM uses `bun`; `ts-node` chokes on this repo's TS6 `bundler` tsconfig).

### Hardening (net security improvement)
- Pinned-SHA actions, `persist-credentials: false`, and least-privilege `permissions:` across the touched workflows. This **removes ~50 pre-existing zizmor findings** and introduces **zero** new ones.
- CodeQL bumped v2 → v3 (v2 runner is deprecated); two pre-existing actionlint bugs fixed in touched files (`static-testing.yml`'s undefined `cache-pnpm-packages` step ref, `security-testing.yml`'s `runner.workspace`).

### Docs
- `CLAUDE.md`, `agents.md`, `CONTRIBUTING.md` document the parallel layout, concurrency policy, caching, and the mutation shard/merge gate. `tests/bats/make-target-coverage.tsv` registers the two new Make targets.

## Acceptance criteria

- [x] Every workflow declares `concurrency` with `cancel-in-progress` (PR gates `true`; deploy/release/sandbox `false` for production safety).
- [x] Node jobs reuse a cached dependency install (pnpm store), verifiable in the YAML.
- [x] `performance-testing.yml` runs desktop/mobile as a parallel matrix; the load suites shard across a matrix.
- [x] Mutation is sharded; the merge job enforces the **unchanged** `break` over the union with a unit-tested merge script; base thresholds unchanged (diff shows no `stryker.config.mjs` change).
- [x] No gate weakened or removed; every PR check still runs on every PR.
- [x] All jobs invoke `make` targets (shard/merge targets added next to the existing ones).
- [x] Least-privilege `permissions:` on every touched workflow (not broadened).
- [x] `CLAUDE.md` / `agents.md` / `CONTRIBUTING.md` updated.

## Verification

- **actionlint**: clean on all workflows.
- **zizmor**: 0 new findings; ~50 pre-existing findings removed (per-file counts compared against `main`).
- **shellcheck**: only pre-existing findings in the untouched AWS scripts of `sandbox-*.yml`.
- **Merge gate**: `merge-mutation-reports.ts` validated on pass (100%→exit 0), fail (survivor→exit 1), missing-shard, and no-valid-mutants paths; shard split proven a total partition (`union == mutate`).
- **Unit test**: 10/10 pass in both client and server envs.
- **`make lint`**: tsc, ESLint, dependency-cruiser, markdownlint all clean; Prettier clean on changed files.
- **Bats contract** (`issue_175_contract.bats` + `makefile_targets.bats`): all pass with the new manifest rows.
- **`pnpm install --frozen-lockfile`**: succeeds (lockfile growth is `esbuild` peer-context re-keying from `tsx`; no dep version changed).

## No conflict with the rust-code-analysis PR (#315)

Verified with a real 3-way trial merge (`git merge-tree`): **clean, zero conflicts**. The manifest rows were placed mid-file (after `test-mutation`) so RCA's EOF append to the same `.tsv` doesn't collide, and the post-merge Makefile↔manifest set is complete — the Bats contract passes after both PRs land. This PR branches from `main` and does not touch `rust-code-analysis.yml` (which already ships its own concurrency block).

## Notes / scope

- The heavy Docker-boot jobs (e2e, visual, memory-leak) keep CRM's proven structure and reuse the same `make` targets; a cross-workflow Docker **image** cache is intentionally out of scope here (the `docker-compose.test.yml` services are untagged, so they can't be safely pre-seeded without restructuring compose) — the win in this PR is concurrency cancellation (removes duplicated superseded builds), parallel matrices, and the pnpm-store cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes the PR CI pipeline (issue #316) so each PR is gated by the slowest single job, not the sum. All checks and thresholds are unchanged; deploy/release/sandbox and image-optimization runs stay serialized for safety.

- **Refactors**
  - Add `concurrency` to all workflows; PR checks cancel superseded runs, while deploy/release/sandbox/image-optimization queue.
  - Run Lighthouse and K6 as matrices; shard Playwright e2e 4 ways; shard mutation tests and merge reports to enforce the exact `break` gate (fails closed). Shard count is single-sourced in the workflow env and the shard index is validated.
  - Cache the `pnpm` store across Node jobs; use `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`. In static testing, install the repo-pinned `pnpm` and key the `node_modules` cache with `.nvmrc`.
  - Harden workflows (least-privilege permissions, pinned actions). CodeQL upgraded to v3 with its DB path pinned to hit cache; docs and Make targets updated.

- **Dependencies**
  - Add `tsx` (dev) to run the mutation-report merge CLI; no app code changes.

<sup>Written for commit 484720a006365dc92dcd277c9e4594dd7a9ee99c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

