### PR TITLE
ci(#324): harden CI/CD reliability — timeouts, Playwright retries, deploy smoke test

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
 

--- a/.github/workflows/bats-testing.yml
+++ b/.github/workflows/bats-testing.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   bats:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   codecov:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:

--- a/.github/workflows/dependency-cruiser.yml
+++ b/.github/workflows/dependency-cruiser.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   dependency-cruiser:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CI: 1
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
     # rather than failing the deploy workflow.
     if: ${{ vars.PRODUCTION_SITE_URL != '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:
@@ -73,10 +73,10 @@ jobs:
             label="$2"
             marker="$3"
             url="${base}${path}"
-            attempts=30
-            delay=20
+            attempts=24
+            delay=15
             for i in $(seq 1 "$attempts"); do
-              if body="$(curl -fsS --max-time 30 "$url")" \
+              if body="$(curl -fsS --max-time 15 "$url")" \
                 && printf '%s' "$body" | grep -Eiq "$marker"; then
                 echo "✓ ${label} (${url}) returned 200 and matched /${marker}/i"
                 return 0
@@ -84,9 +84,18 @@ jobs:
               echo "… ${label} not ready (attempt ${i}/${attempts}); retrying in ${delay}s"
               sleep "$delay"
             done
-            echo "::error::${label} (${url}) failed smoke test after $((attempts * delay))s"
+            echo "::error::${label} (${url}) failed smoke test"
             return 1
           }
 
-          probe "/" "homepage" "__next|<title"
-          probe "/swagger" "swagger page" "swagger"
+          # Probe both endpoints in parallel so each is fully tested within the
+          # job timeout regardless of the other's outcome (they deploy together).
+          probe "/" "homepage" "__next|<title" &
+          home_pid=$!
+          probe "/swagger" "swagger page" "swagger" &
+          swagger_pid=$!
+
+          rc=0
+          wait "$home_pid" || rc=1
+          wait "$swagger_pid" || rc=1
+          exit "$rc"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,14 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Gate the prod deploy behind a GitHub Environment so protection rules
+    # (required reviewers / wait timer) can be enforced from repo Settings →
+    # Environments → production. `url` surfaces the live site in the deployment
+    # timeline once the PRODUCTION_SITE_URL repo variable is set.
+    environment:
+      name: production
+      url: ${{ vars.PRODUCTION_SITE_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,3 +44,49 @@ jobs:
       - name: Trigger CodePipeline
         run: |
           aws codepipeline start-pipeline-execution --name ci-cd-website-prod-pipeline
+
+  post-deploy-smoke:
+    name: post-deploy smoke test
+    needs: deploy
+    # The smoke test needs a public URL to probe. Until a maintainer sets the
+    # PRODUCTION_SITE_URL repository variable (Settings → Secrets and variables →
+    # Actions → Variables — see docs/deployment-runbook.md) the job skips cleanly
+    # rather than failing the deploy workflow.
+    if: ${{ vars.PRODUCTION_SITE_URL != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Smoke-test homepage and /swagger
+        env:
+          # CodePipeline deploys asynchronously, so the probe retries until the
+          # CDN serves the new build (or the job times out).
+          SITE_URL: ${{ vars.PRODUCTION_SITE_URL }}
+        run: |
+          set -euo pipefail
+
+          base="${SITE_URL%/}"
+
+          probe() {
+            path="$1"
+            label="$2"
+            marker="$3"
+            url="${base}${path}"
+            attempts=30
+            delay=20
+            for i in $(seq 1 "$attempts"); do
+              if body="$(curl -fsS --max-time 30 "$url")" \
+                && printf '%s' "$body" | grep -Eiq "$marker"; then
+                echo "✓ ${label} (${url}) returned 200 and matched /${marker}/i"
+                return 0
+              fi
+              echo "… ${label} not ready (attempt ${i}/${attempts}); retrying in ${delay}s"
+              sleep "$delay"
+            done
+            echo "::error::${label} (${url}) failed smoke test after $((attempts * delay))s"
+            return 1
+          }
+
+          probe "/" "homepage" "__next|<title"
+          probe "/swagger" "swagger page" "swagger"

--- a/.github/workflows/dockerfile-performance.yml
+++ b/.github/workflows/dockerfile-performance.yml
@@ -27,6 +27,7 @@ jobs:
   setup:
     name: resolve matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -47,6 +48,7 @@ jobs:
     name: ${{ matrix.name }}
     needs: setup
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:
@@ -99,6 +101,7 @@ jobs:
     needs: performance
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -21,6 +21,7 @@ jobs:
     # prod stack and is fully independent.
     name: e2e shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/image-optimization.yml
+++ b/.github/workflows/image-optimization.yml
@@ -22,6 +22,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:

--- a/.github/workflows/load-testing.yml
+++ b/.github/workflows/load-testing.yml
@@ -17,6 +17,7 @@ jobs:
     # homepage and Swagger suites run in parallel instead of one after another.
     name: ${{ matrix.label }} load testing
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
 

--- a/.github/workflows/memory-leak-testing.yml
+++ b/.github/workflows/memory-leak-testing.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   memory-leak-testing:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -22,6 +22,7 @@ jobs:
   shard:
     name: shard ${{ matrix.index }}
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
       contents: read
     strategy:
@@ -80,6 +81,7 @@ jobs:
     # required check as passing — silently bypassing the mutation gate.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 

--- a/.github/workflows/performance-testing.yml
+++ b/.github/workflows/performance-testing.yml
@@ -22,6 +22,7 @@ jobs:
     # run in parallel, cutting the job's wall-clock roughly in half.
     name: lighthouse ${{ matrix.formFactor }}
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/sandbox-creating.yml
+++ b/.github/workflows/sandbox-creating.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   check-tokens:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Validate AWS Region
         run: |
@@ -114,6 +115,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [check-tokens]
     steps:
       - name: Checkout repository

--- a/.github/workflows/sandbox-deleting.yml
+++ b/.github/workflows/sandbox-deleting.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   trigger-sandbox-deletion-pipeline:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Validate environment variables
         run: |

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -15,6 +15,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/static-testing.yml
+++ b/.github/workflows/static-testing.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   static:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       CI: 1
     steps:

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   visual-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
       contents: read
     steps:

--- a/.github/workflows/yaml-formater.yml
+++ b/.github/workflows/yaml-formater.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   yamlfmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/README.md
+++ b/README.md
@@ -393,6 +393,9 @@ If you're having trouble, head for
 [the troubleshooting guide](https://github.com/VilnaCRM-Org/frontend-ssr-template/wiki/Troubleshooting)
 as it's frequently updated.
 
+For production deploys, the post-deploy smoke test, and the rollback procedure,
+see the [deployment and rollback runbook](docs/deployment-runbook.md).
+
 You can generate complete API-level documentation by running `doc` in the top-level
 folder, and documentation will appear in the `docs` folder, though you'll need to have
 [API-Extractor](https://api-extractor.com/) installed.

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -1,0 +1,81 @@
+# Deployment and rollback runbook
+
+How the VilnaCRM website reaches production, how the post-deploy smoke test
+verifies a release, and how to roll back a bad deploy.
+
+## How a production deploy works
+
+Every push to `main` triggers
+[`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml). The `deploy`
+job assumes an AWS role through OIDC and calls
+`aws codepipeline start-pipeline-execution` on the `ci-cd-website-prod-pipeline`
+pipeline. CodePipeline then builds the static export and publishes it to the CDN
+**asynchronously** — the GitHub job finishes once the pipeline is _triggered_,
+not once the new build is live.
+
+The `deploy` job runs inside the `production` GitHub Environment so the release
+can be gated by environment protection rules (see below).
+
+## Post-deploy smoke test
+
+After `deploy` succeeds, the `post-deploy-smoke` job probes the live site and
+fails if it does not serve valid content:
+
+- `GET /` — expects HTTP `200` and HTML containing `__next` (the Next.js root)
+  or a `<title>`.
+- `GET /swagger` — expects HTTP `200` and a body mentioning `swagger`.
+
+Because CodePipeline deploys asynchronously, each probe retries (up to roughly
+ten minutes) until the CDN serves the new build or the job times out.
+
+### One-time setup
+
+The smoke test needs to know the public site URL. Until it is configured the
+job **skips cleanly**, so `main` stays green.
+
+1. Add a repository **variable** named `PRODUCTION_SITE_URL` set to the site
+   origin (for example `https://vilnacrm.com`) under _Settings → Secrets and
+   variables → Actions → Variables_.
+2. Confirm the next deploy runs the `post-deploy smoke test` job and that both
+   probes pass.
+
+### Environment protection rules
+
+`deploy.yml` references the `production` environment. To require a human
+checkpoint before a production deploy, add protection rules under _Settings →
+Environments → production_:
+
+- **Required reviewers** — the deploy waits for approval before CodePipeline is
+  triggered.
+- **Wait timer** — an optional delay before the job runs.
+
+No rules are enforced by default; adding them is a repo-settings change and does
+not require a code change.
+
+## Rollback procedure
+
+Production serves whatever the pipeline last published, so rolling back means
+publishing a known-good revision again.
+
+**Preferred — revert on `main`.** Identify the last known-good commit, revert
+the offending commit(s), and push. The push re-triggers `deploy.yml`, which
+redeploys the reverted state and re-runs the smoke test:
+
+```bash
+git revert --no-edit <bad-commit-sha>
+git push origin main
+```
+
+**Alternative — re-run the pipeline.** If the fix is not a code change (for
+example a bad environment variable), re-run `ci-cd-website-prod-pipeline` from
+the AWS CodePipeline console against the last successful source revision.
+
+## Manual verification
+
+To check production by hand at any time (replace the host with the value of
+`PRODUCTION_SITE_URL`):
+
+```bash
+curl -fsSI https://vilnacrm.com/ | head -n 1
+curl -fsS https://vilnacrm.com/swagger | grep -i swagger
+```

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
   testMatch: ['**/*.spec.ts'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
+  // Retry twice in CI so a transient cross-container/network blip self-heals
+  // instead of failing the run; this also activates `trace: 'on-first-retry'`
+  // below (dead config while retries were 0). Locally retries stay at 0.
+  retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: [['html', { open: 'never' }]],
   use: {


### PR DESCRIPTION
## What & why

Implements **item 9 — Reliability / availability (3/5)** of the enterprise-readiness
audit #322. That attribute was dragged down by CI/CD jobs that could hang for the full
6-hour default, dead Playwright retry config, and a production deploy with no post-deploy
verification, no environment gate, and no documented rollback path.

Closes #324. Tracks #322.

## Changes

### Workflow job timeouts (`.github/workflows/*.yml`)

Added `timeout-minutes` to **every** job that lacked one (24 jobs across 20 workflows;
only `rust-code-analysis.yml` had one before). A hung job can no longer burn the 6h
default and pin a runner. Values are calibrated **above observed p100 run times** with
headroom (and headroom for the new Playwright retries):

| Kind | Jobs | timeout |
| --- | --- | --- |
| trigger / format / matrix-setup | deploy, yaml-formater, dockerfile setup/comment, rca | 10–15m |
| install + unit / lint | unit, codecov, integration, static, bats, dep-cruiser, autorelease, image, sandbox | 15–20m |
| build + heavy suite | performance 25m, load 30m, memory-leak 30m, security 30m, dockerfile perf 30m |
| slowest (build + browsers/mutation, ×retries) | e2e 40m, visual 40m, mutation shard 40m |

### Playwright CI retries (`playwright.config.ts`)

`retries: process.env.CI ? 2 : 0` — a transient cross-container/network blip now
self-heals instead of failing the run, and this **activates the previously-dead
`trace: 'on-first-retry'`**. Local runs stay at `0`. Retries only affect *failing* tests,
so passing suites are unchanged.

### Post-deploy smoke test + environment (`deploy.yml`)

- New `post-deploy-smoke` job probes the live **homepage** and **`/swagger`** for
  HTTP `200` + key content, retrying (~10 min) to absorb the **asynchronous** AWS
  CodePipeline rollout (the `deploy` job returns as soon as the pipeline is *triggered*).
- The prod deploy runs in a **`production` GitHub Environment** so it can be gated by
  protection rules (required reviewers / wait timer) from repo settings.
- The smoke job is gated on a `PRODUCTION_SITE_URL` repo variable and **skips cleanly**
  until a maintainer sets it — so `main` stays green with zero setup.

### Docs

`docs/deployment-runbook.md` documents the deploy flow, the smoke-test one-time setup,
environment protection, and the **rollback procedure** (revert-on-`main` → re-deploy, or
re-run the pipeline). Linked from the README Documentation section.

## Locked-config note

Per the Locked Configuration Policy, `playwright.config.ts` and the workflow files are
gate configs. The user explicitly requested this work (#322 item 9); no threshold is
lowered and no `eslint-disable` / `ts-ignore` / `prettier-ignore` / markdownlint-disable
is introduced. Rollback = revert this PR.

## Deferred

**Merge queue (`merge_group`)** — listed as *"Consider"* in #322 and requires
branch-protection settings only a repo admin can apply; kept out to keep this reliability
change focused. Recommend a dedicated follow-up.

## Verification

- `make lint` (eslint + tsc + markdownlint + dependency-cruiser) — **clean** (535 modules,
  0 dependency violations).
- `actionlint` on all workflows — **clean**.
- `yamlfmt` with `norwd/fmtya`'s exact config — my edits introduce **no new** formatting
  diffs vs `origin/main`.
- `prettier --check` on `playwright.config.ts`, `README.md`, `docs/deployment-runbook.md`
  — **clean**; `markdownlint` on the docs — **clean**.

> Note: `deploy.yml` runs only on push to `main`, so its runtime changes execute
> post-merge (not in this PR's checks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boosts CI/CD reliability by adding per-job timeouts, CI-only Playwright retries, and a post-deploy smoke test that now probes endpoints in parallel. Addresses enterprise-readiness audit #322 item 9; closes #324.

- **New Features**
  - Added `timeout-minutes` to all workflow jobs to prevent 6h hangs; values set above observed p100.
  - Enabled Playwright retries in CI (`retries: process.env.CI ? 2 : 0`), activating `trace: 'on-first-retry'`; local stays at 0.
  - Production deploy uses a `production` GitHub Environment; `post-deploy-smoke` probes `/` and `/swagger` in parallel, retries (~12m) to absorb async rollout; job timeout raised to 25m; gated by `PRODUCTION_SITE_URL` and skips until set.
  - Added `docs/deployment-runbook.md` and linked from README, covering deploy flow, smoke-test setup, and rollback.

<sup>Written for commit 59bcddf3dbfe1dafbc06387988d2eba92bc12b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

