### PR TITLE
ci(#375): sandbox PR number from the pull_request event (fix red deploy check)

### DIFF
--- a/.claude/skills/ci-infrastructure-failure-diagnosis/SKILL.md
+++ b/.claude/skills/ci-infrastructure-failure-diagnosis/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: ci-infrastructure-failure-diagnosis
+description: Use when GitHub Actions sandbox/deploy checks fail across multiple PRs/branches — diagnose whether the failure is code-specific or repo-wide infrastructure. Triggers on "deploy check red", "sandbox failing", "all my PRs failing at deploy", "check-tokens failure", or when troubleshooting CI red flags that affect unrelated branches.
+---
+
+# CI Infrastructure Failure Diagnosis
+
+When GitHub Actions checks fail red, especially the `deploy` (sandbox) job, determine whether the failure is caused by:
+
+1. Code in the PR (fix in code)
+2. Repo-wide infrastructure (escalate to ops)
+
+This skill covers the `deploy` job in `.github/workflows/sandbox-creating.yml` (the `sandbox` workflow), which historically retrieved the PR number via a GitHub API call using a token stored in AWS Secrets Manager — not `github.token`. (`sandbox-deleting.yml` mirrored the same token retrieval.)
+
+> **Resolved in code (#375).** The sandbox `deploy` job no longer looks up the PR number via that token — it now reads `PR_NUMBER` straight from `${{ github.event.pull_request.number }}`, so an expired `github-token-*` secret can no longer make this check fail. The timeline + cross-branch methodology below still applies to any _other_ shared-infrastructure CI failure.
+
+## Quick diagnostic: timeline + consistency
+
+**Step 1: Check the timeline**
+
+Look at the GitHub Actions run history (repo > Actions > All workflows > deploy).
+
+- When was the last successful sandbox run?
+- Did every run since then fail at the same step?
+
+If the last successful run is 3+ days old and every run since then fails at the same step, the failure is **almost certainly infrastructure**, not your code.
+
+Example:
+
+```
+Last green: 2026-07-03T13:14:07Z
+Today's runs: all red since 2026-07-06T07:37:00Z
+→ Timeline cutoff = infrastructure incident
+```
+
+**Step 2: Check consistency across branches**
+
+Look at recent runs on **multiple unrelated branches** (main, feat/_, chore/_, ci/\*, etc.).
+
+- Does the same failure happen on all of them at the same step?
+
+If both `feat/328` and `chore/364` fail at "Get PR Number" in the sandbox job, it's not your code — it's a shared resource (token, API, secret).
+
+**Step 3: For the `deploy` job's "Get PR Number" step**
+
+The sandbox workflow runs an API query to fetch the PR number:
+
+```bash
+gh api "repos/VilnaCRM-Org/website/pulls?state=open&head=VilnaCRM-Org:${GITHUB_REF_NAME}" --jq '.[] | .number'
+```
+
+It pulls the GitHub token from **AWS Secrets Manager** (not `github.token`). If the job returns empty PR number:
+
+1. **Test the query manually** with your own GitHub token:
+
+   ```bash
+   gh api "repos/VilnaCRM-Org/website/pulls?state=open&head=VilnaCRM-Org:<your-branch-name>" --jq '.[] | .number'
+   ```
+
+   If this returns your PR number, the query is correct and the issue is the stored token.
+
+2. **Check the GitHub Actions logs** for the exact error:
+   - Is it "Unauthorized" (401)?
+   - Is it "token expired"?
+   - Or just empty output?
+
+3. **If the stored token is invalid/expired**, that's the fix: rotate the `github-token-*` secret in AWS Secrets Manager (ops action, not code).
+
+**Signs of an expired token in AWS Secrets Manager:**
+
+- Your API query works with a fresh token, but the workflow gets empty result
+- GitHub Actions logs show "401 Unauthorized" or timeout
+- Timeline shows a clean cutoff: green runs until date X, then all red
+- Affects all branches equally (not just your PR)
+
+## Confirming it's infrastructure (not your code)
+
+Checklist before escalating:
+
+- [ ] Timeline: last green run is 3+ days old ✓
+- [ ] Cross-branch: same failure on 2+ unrelated branches ✓
+- [ ] Code: the PR contains no infrastructure changes (no workflow edits, no secret refs) ✓
+- [ ] Manual test: API query works with your token but workflow fails ✓
+
+If all four are true, it's infrastructure.
+
+## How to file the tracking issue
+
+Example issue title and body:
+
+**Title:** Sandbox `deploy` job: GitHub token in AWS Secrets Manager expired (~2026-07-03)
+
+**Body:**
+
+```
+## Symptom
+Sandbox `deploy` check fails on all PRs/branches at "Get PR Number" step.
+
+## Evidence
+- Last successful sandbox run: 2026-07-03T13:14:07Z (feat/328)
+- Every run since 2026-07-06T07:37:00Z fails at same step (feat/328, chore/364, ci/358)
+- API query `gh api "repos/VilnaCRM-Org/website/pulls?state=open&head=VilnaCRM-Org:<branch>"` returns PR number with fresh token
+- Same query in sandbox job workflow returns empty (stored token invalid)
+
+## Root Cause
+GitHub token stored in AWS Secrets Manager (pulled by the `deploy` job in `.github/workflows/sandbox-creating.yml`) is expired or invalid.
+
+## Fix Required (ops)
+Rotate `github-token-*` secret in AWS Secrets Manager.
+
+## Timeline Impact
+All PRs since 2026-07-03 have red `deploy` checks (regardless of code quality).
+```
+
+Include the timeline, branches, and the manual test result — that proves it's infrastructure.
+
+## What NOT to do
+
+- ❌ Do not add `set -e` flags to the workflow to "skip" the failing step
+- ❌ Do not commit a workaround in code (the issue is not in code)
+- ❌ Do not lower the check's required status (the check itself is fine; the secret is broken)
+- ❌ Do not assume "re-running will fix it" (re-running uses the same expired token)
+
+## Related
+
+- **Before this step:** See [`ci-workflow`](../ci-workflow/SKILL.md) for pre-commit/pre-PR validation when code changes are made.
+- **For code CI failures:** Use `ci-workflow`'s "When a gate fails" section to fix ESLint, TypeScript, Jest, Playwright, etc.
+- **For AWS Secrets Manager ops:** Escalate to DevOps / infrastructure team; provide the issue evidence above.

--- a/.github/workflows/sandbox-creating.yml
+++ b/.github/workflows/sandbox-creating.yml
@@ -2,18 +2,15 @@ name: sandbox
 
 on:
   pull_request:
-    types: [opened]
-  push:
-    branches-ignore: [main]
+    types: [opened, reopened, synchronize]
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION }}
+  PROD_AWS_ACCOUNT_ID: ${{ vars.PROD_AWS_ACCOUNT_ID }}
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
 
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: read
+permissions: {}
 
 # Serialize sandbox provisioning per branch/PR without cancelling: aborting an
 # in-flight AWS pipeline trigger mid-run is unsafe.
@@ -23,18 +20,24 @@ concurrency:
 
 jobs:
   check-tokens:
+    # Same-repo guard: fork PRs receive no OIDC id-token and no secrets, so the
+    # prod-account role assumptions below can only run for branches in this repo.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Validate AWS Region
         run: |
-          if [ -z "${{ vars.AWS_REGION }}" ]; then
+          if [ -z "${AWS_REGION}" ]; then
             echo "::error::AWS_REGION is not set"
             exit 1
           fi
 
       - name: Configure AWS Credentials (Test)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::${{vars.TEST_AWS_ACCOUNT_ID}}:role/github-actions-role
           aws-region: ${{ env.AWS_REGION }}
@@ -74,7 +77,7 @@ jobs:
           fi
 
       - name: Configure AWS Credentials (Prod)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::${{vars.PROD_AWS_ACCOUNT_ID}}:role/github-actions-role
           aws-region: ${{ env.AWS_REGION }}
@@ -114,70 +117,50 @@ jobs:
           fi
 
   deploy:
+    # Same-repo guard: fork PRs receive no OIDC id-token, so the prod-account
+    # sandbox-creation trigger can only run for branches in this repo.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [check-tokens]
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{vars.PROD_AWS_ACCOUNT_ID}}:role/github-actions-role
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Retrieve GitHub Token from Secrets Manager
+      # PR_NUMBER comes straight from the pull_request event payload, so no
+      # GitHub token or API round-trip is needed to discover it. This drops the
+      # Secrets-Manager-token dependency that broke this job whenever the stored
+      # token expired, and no longer writes that token to $GITHUB_ENV.
+      - name: Validate environment variables
         run: |
-          SECRET_ID=$(aws secretsmanager list-secrets \
-            --region "${AWS_REGION}" \
-            --query "SecretList[?starts_with(Name, 'github-token-') && DeletionDate==null].Name | [0]" \
-            --output text)
-
-          if [ -z "$SECRET_ID" ] || [ "$SECRET_ID" = "None" ]; then
-            echo "No active secret found with prefix 'github-token-'"
+          if [ -z "${AWS_REGION}" ]; then
+            echo "::error::AWS_REGION is not set"
             exit 1
           fi
-
-          GITHUB_TOKEN=$(aws secretsmanager get-secret-value \
-            --region "${AWS_REGION}" \
-            --secret-id "$SECRET_ID" \
-            --query "SecretString" \
-            --output text | jq -r '.token')
-
-          if [ -z "$GITHUB_TOKEN" ]; then
-            echo "Error: Unable to extract GitHub token from secret"
+          if [ -z "${PROD_AWS_ACCOUNT_ID}" ]; then
+            echo "::error::PROD_AWS_ACCOUNT_ID is not set"
             exit 1
           fi
-
-          echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
-
-      - name: Get PR Number
-        id: get_pr_number
-        run: |
-          RESPONSE=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?head=${GITHUB_REPOSITORY_OWNER}:${BRANCH_NAME}")
-
-          if [ $? -ne 0 ]; then
-            echo "::error::Failed to retrieve PR number: ${PR_NUMBER}"
+          if [ -z "${BRANCH_NAME}" ]; then
+            echo "::error::BRANCH_NAME is not set"
             exit 1
           fi
-          PR_NUMBER=$(echo "$RESPONSE" | jq -r 'if type == "array" then .[0].number // empty else empty end')
-          if [ -z "$PR_NUMBER" ] && [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            echo "::error::PR number extraction failed for branch ${BRANCH_NAME}"
+          if [ -z "${PR_NUMBER}" ] || [ "${PR_NUMBER}" = "null" ]; then
+            echo "::error::PR_NUMBER is not set"
             exit 1
           fi
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials (Sandbox Creation Trigger Role)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          role-to-assume: arn:aws:iam::${{vars.PROD_AWS_ACCOUNT_ID}}:role/sandbox-creation-trigger-role
+          role-to-assume: arn:aws:iam::${{ env.PROD_AWS_ACCOUNT_ID }}:role/sandbox-creation-trigger-role
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Start Pipeline Execution
         run: |
           aws codepipeline start-pipeline-execution --name "sandbox-creation" \
-            --variables "name=BRANCH_NAME,value=${BRANCH_NAME}" "name=PR_NUMBER,value=${PR_NUMBER}" "name=IS_PULL_REQUEST,value=1"
+            --variables \
+            "name=BRANCH_NAME,value=${BRANCH_NAME}" \
+            "name=PR_NUMBER,value=${PR_NUMBER}" \
+            "name=IS_PULL_REQUEST,value=1"

--- a/.github/workflows/sandbox-deleting.yml
+++ b/.github/workflows/sandbox-deleting.yml
@@ -7,12 +7,11 @@ on:
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION }}
+  PROD_AWS_ACCOUNT_ID: ${{ vars.PROD_AWS_ACCOUNT_ID }}
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
 
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: read
+permissions: {}
 
 # Serialize sandbox teardown per branch/PR without cancelling: aborting an
 # in-flight AWS pipeline trigger mid-run is unsafe.
@@ -22,78 +21,45 @@ concurrency:
 
 jobs:
   trigger-sandbox-deletion-pipeline:
+    # Same-repo guard: fork PRs receive no OIDC id-token, so the prod-account
+    # sandbox-deletion trigger can only run for branches in this repo.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      # PR_NUMBER comes straight from the pull_request event payload, so no
+      # GitHub token or API round-trip is needed to discover it. The teardown
+      # trigger only needs OIDC access to the sandbox-deletion role.
       - name: Validate environment variables
         run: |
-          if [ -z "${{ env.AWS_REGION }}" ]; then
+          if [ -z "${AWS_REGION}" ]; then
             echo "::error::AWS_REGION variable is not set"
             exit 1
           fi
-          if [ -z "${{ vars.PROD_AWS_ACCOUNT_ID }}" ]; then
+          if [ -z "${PROD_AWS_ACCOUNT_ID}" ]; then
             echo "::error::PROD_AWS_ACCOUNT_ID variable is not set"
             exit 1
           fi
+          if [ -z "${BRANCH_NAME}" ]; then
+            echo "::error::BRANCH_NAME variable is not set"
+            exit 1
+          fi
+          if [ -z "${PR_NUMBER}" ] || [ "${PR_NUMBER}" = "null" ]; then
+            echo "::error::PR_NUMBER variable is not set"
+            exit 1
+          fi
 
-      - name: Configure AWS Credentials (Prod)
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Configure AWS Credentials (Sandbox Deletion Trigger Role)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          role-to-assume: arn:aws:iam::${{vars.PROD_AWS_ACCOUNT_ID}}:role/github-actions-role
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Retrieve GitHub Token from Secrets Manager
-        run: |
-          if ! command -v jq &> /dev/null; then
-            echo "::error::jq is required but not installed"
-            exit 1
-          fi
-
-          SECRET_ID=$(aws secretsmanager list-secrets \
-            --region "${AWS_REGION}" \
-            --query "SecretList[?starts_with(Name, 'github-token-') && DeletionDate==null].Name | [0]" \
-            --output text)
-
-          if [ -z "$SECRET_ID" ] || [ "$SECRET_ID" = "None" ]; then
-            echo "No active secret found with prefix 'github-token-'"
-            exit 1
-          fi
-
-          GITHUB_TOKEN=$(aws secretsmanager get-secret-value \
-            --region "${AWS_REGION}" \
-            --secret-id "$SECRET_ID" \
-            --query "SecretString" \
-            --output text | jq -r '.token')
-
-          if [ -z "$GITHUB_TOKEN" ]; then
-            echo "Error: Unable to extract GitHub token from secret"
-            exit 1
-          fi
-
-          echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
-
-      - name: Get PR Number
-        id: get_pr_number
-        run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          if [ -z "$PR_NUMBER" ]; then
-            echo "::error::PR number extraction failed; received an empty value"
-            exit 1
-          fi
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{vars.PROD_AWS_ACCOUNT_ID}}:role/sandbox-deletion-trigger-role
+          role-to-assume: arn:aws:iam::${{ env.PROD_AWS_ACCOUNT_ID }}:role/sandbox-deletion-trigger-role
           aws-region: ${{ env.AWS_REGION }}
 
       - name: trigger sandbox deletion pipeline
         run: |
-          PR_NUMBER="${{ env.PR_NUMBER }}"
           if ! aws codepipeline start-pipeline-execution \
             --name "sandbox-deletion" \
             --variables \


### PR DESCRIPTION
## What & why

The sandbox `deploy` check has been failing red on **every open PR** (including today's #385 and #384). The failure is **not** in those PRs — neither touches the sandbox workflow. The root cause is in `sandbox-creating.yml`:

The `deploy` job fetched a GitHub token from **AWS Secrets Manager** and used it to look up the PR number via the GitHub API. That stored token expired, so the API returned empty and `PR_NUMBER` came back empty:

- **`pull_request` run** → empty `PR_NUMBER` → guard `exit 1` at "Get PR Number".
- **`push` run** (`branches-ignore: [main]`) → continued with an empty `PR_NUMBER` → `aws codepipeline start-pipeline-execution … value=` → **ParamValidation**, exit 252.

Proof it was the token and not the query: the same `?head=…` query with a fresh token returns the PR numbers correctly.

## The fix (ported from `VilnaCRM-Org/crm`)

CRM's sandbox workflows don't use a token at all — they read the PR number straight from the event payload. Ported here, keeping the website's own AWS resource names (`sandbox-creation` / `sandbox-creation-trigger-role`, `sandbox-deletion` / `sandbox-deletion-trigger-role`):

- **`PR_NUMBER: ${{ github.event.pull_request.number }}`** from the event — no token, no API round-trip. Removed the Secrets-Manager token retrieval, the API PR-number lookup, and the now-unused `checkout` steps.
- **Trigger** sandbox creation on `pull_request: [opened, reopened, synchronize]`; **dropped** `push: branches-ignore: [main]` (the empty-`PR_NUMBER`/ParamValidation path).
- **Same-repo guard** `if: github.event.pull_request.head.repo.full_name == github.repository` on every prod-account job.
- **Least-privilege permissions**: top-level `permissions: {}` + per-job `id-token: write` + `contents: read`; dropped the unused `pull-requests: read`.
- **SHA-pinned** `aws-actions/configure-aws-credentials@7474bc46… # v4` (matches the repo's already-hardened workflows, e.g. `yaml-formater.yml`).
- The `check-tokens` rotation monitor is **kept** (it only reports rotation status; it never writes a token to `$GITHUB_ENV`).

## Relation to #375 (CI/CD pipeline integrity)

This implements the code-level parts of **F1** (same-repo guard + drop the any-branch-push trigger) and fully resolves **F4** (Secrets-Manager token written to `$GITHUB_ENV`) for the sandbox workflows. Out of scope / still tracked by #375: adding a GitHub `environment:` approval gate and the broader cross-repo action-pinning sweep.

`Refs #375`

## Also in this PR

Adds the `ci-infrastructure-failure-diagnosis` skill (`.claude/skills/`) that captures the timeline + cross-branch methodology used to root-cause this failure (distinguishing repo-wide infrastructure from PR code). It carries a note that #375 resolves the specific expired-token failure mode in code.

## Verification

- `zizmor --offline` — clean on both files (no `excessive-permissions`, no `template-injection`).
- Pinned SHA `7474bc46…` verified to be the commit behind `aws-actions/configure-aws-credentials`'s `v4` tag.
- Both files parse as valid workflow YAML.

## Follow-up

Once this is on `main`, PRs #385 and #384 pick up the fixed workflow when their branches are updated with `main` (a plain re-run reuses the old merge ref). The expired `github-token-*` secret in AWS Secrets Manager is no longer on the sandbox `deploy` path, but should still be rotated by ops if anything else consumes it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox deploy check by reading the PR number from the pull_request event and removing the Secrets Manager token dependency. Hardens the sandbox workflows per #375 and adds a CI failure-diagnosis skill.

- **Bug Fixes**
  - Derive `PR_NUMBER` from `github.event.pull_request.number`; removed the Secrets Manager token retrieval and GitHub API lookup that caused empty PR numbers and red checks.
  - Trigger only on `pull_request` (opened, reopened, synchronize); removed the `push` trigger that led to ParamValidation when `PR_NUMBER` was empty.

- **Refactors**
  - Hardened workflows: added a same-repo guard on prod-account jobs; set top-level `permissions: {}` with per-job least-privilege; SHA-pinned `aws-actions/configure-aws-credentials`.
  - Simplified jobs and validation: removed unused checkout steps, kept `check-tokens`, and added env validation to avoid silent misconfig.

<sup>Written for commit 5f82f33aba08edfa61c9fabf16af523c7f271c0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

