### PR TITLE
ci(#346): add 5 independent ci-gap gates (scorecard, canary, alerts, commitlint, fuzz)

### DIFF
--- a/.github/workflows/ci-health-alerts.yml
+++ b/.github/workflows/ci-health-alerts.yml
@@ -1,0 +1,95 @@
+name: ci health alerts
+
+on:
+  workflow_run:
+    workflows:
+      - website
+      - Generate Changelog and Create Release
+    types:
+      - completed
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  alert:
+    # Post-merge detection half of CI health (#365): even a perfect PR gate says
+    # nothing once main, the deploy workflow, or the release workflow breaks and
+    # nobody is told. This files/refreshes a labelled tracking issue on those
+    # failures and on a red default branch, and closes it on recovery. It has no
+    # pull_request trigger, so it never gates a PR.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - name: Alert on a failed deploy or release run
+        if: >-
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          title="CI health: '$WORKFLOW_NAME' workflow is failing"
+          existing="$(gh issue list --label ci-alert --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still failing: $RUN_URL"
+          else
+            gh issue create --label ci-alert --title "$title" \
+              --body "The '$WORKFLOW_NAME' workflow failed. Latest run: $RUN_URL"
+          fi
+
+      - name: Close the alert when the workflow recovers
+        if: >-
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          title="CI health: '$WORKFLOW_NAME' workflow is failing"
+          existing="$(gh issue list --label ci-alert --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Recovered: the workflow is green again. Closing."
+            gh issue close "$existing"
+          fi
+
+      - name: Sweep for a red default branch
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Daily approximation of the "main red > 24h" signal: the sweep runs
+          # once a day and refreshes (comments on) the same issue rather than
+          # duplicating, so a persistently red main keeps one open issue that
+          # auto-closes on the first green sweep.
+          sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')"
+          failed="$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs" \
+            --jq '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out")] | length')"
+          title='CI health: main is red'
+          existing="$(gh issue list --label ci-alert --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          commit_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$sha"
+          if [ "$failed" -gt 0 ]; then
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "main still red at $sha ($failed failing check-run(s)): $commit_url"
+            else
+              gh issue create --label ci-alert --title "$title" \
+                --body "The default branch has $failed failing check-run(s) at $sha: $commit_url"
+            fi
+          elif [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "main is green again at $sha. Closing."
+            gh issue close "$existing"
+          fi

--- a/.github/workflows/ci-health-alerts.yml
+++ b/.github/workflows/ci-health-alerts.yml
@@ -14,10 +14,11 @@ permissions:
   contents: read
 
 concurrency:
-  # One workflow-wide group (not per-event) so the read/create/close sequences
-  # that share ci-alert issue state run serially — concurrent runs cannot
-  # duplicate an issue or close one based on stale state.
-  group: ${{ github.workflow }}
+  # Keyed on the ref; every trigger here operates on main, so runs serialize on
+  # the shared ci-alert issue state (no duplicate/stale-close races) without
+  # blocking unrelated refs. cancel-in-progress is false so a queued alert run is
+  # never dropped.
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -32,9 +33,10 @@ jobs:
     permissions:
       contents: read
       issues: write
-      # The commits/{ref}/check-runs endpoint used by the red-main sweep needs
-      # the Checks read scope.
+      # commits/{ref}/check-runs (red-main sweep) needs Checks read; gh run list
+      # (recovery confirmation) needs Actions read.
       checks: read
+      actions: read
     steps:
       - name: Alert on a failed or timed-out deploy or release run
         if: >-
@@ -72,8 +74,14 @@ jobs:
           title="CI health: '$WORKFLOW_NAME' workflow is failing"
           existing="$(gh issue list --label ci-alert --state open \
             --search "$title in:title" --json number --jq '.[0].number')"
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "Recovered: the workflow is green again. Closing."
+          [ -n "$existing" ] || exit 0
+          # Guard against an out-of-order (stale) success event closing an issue a
+          # newer failed run opened: close only if the LATEST run of this workflow
+          # on main is itself successful.
+          latest="$(gh run list --workflow "$WORKFLOW_NAME" --branch main --limit 1 \
+            --json conclusion --jq '.[0].conclusion')"
+          if [ "$latest" = "success" ]; then
+            gh issue comment "$existing" --body "Recovered: '$WORKFLOW_NAME' is green again (latest main run succeeded). Closing."
             gh issue close "$existing"
           fi
 
@@ -89,14 +97,19 @@ jobs:
           gh label create ci-alert --color B60205 \
             --description "Deploy/release/red-main CI health alerts" 2>/dev/null || true
           sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')"
-          # per_page=100 captures every check-run for the commit in one page
-          # (this repo has well under 100). failed = completed red; incomplete =
-          # still queued/in-progress (no conclusion yet).
+          # per_page=100 captures every check-run for the commit in one page (this
+          # repo has well under 100). failed = any completed run whose conclusion
+          # is not a healthy one (success/neutral/skipped) — this catches
+          # cancelled/action_required/stale/timed_out, not only failure.
+          # incomplete = still queued/in-progress (no conclusion yet).
           runs="$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs?per_page=100")"
-          failed="$(printf '%s' "$runs" | \
-            jq '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out")] | length')"
-          incomplete="$(printf '%s' "$runs" | \
-            jq '[.check_runs[] | select(.status != "completed")] | length')"
+          failed="$(printf '%s' "$runs" | jq '[.check_runs[]
+            | select(.status == "completed"
+              and .conclusion != "success"
+              and .conclusion != "neutral"
+              and .conclusion != "skipped")] | length')"
+          incomplete="$(printf '%s' "$runs" | jq '[.check_runs[]
+            | select(.status != "completed")] | length')"
           title='CI health: main is red'
           existing="$(gh issue list --label ci-alert --state open \
             --search "$title in:title" --json number --jq '.[0].number')"
@@ -109,7 +122,7 @@ jobs:
                 --body "The default branch has $failed failing check-run(s) at $sha: $commit_url"
             fi
           elif [ "$incomplete" -eq 0 ] && [ -n "$existing" ]; then
-            # Only close once every check-run has completed and none failed — a
+            # Close only once every check-run has completed and none is red — a
             # commit whose checks are still running is not "recovered".
             gh issue comment "$existing" --body "main is green again at $sha. Closing."
             gh issue close "$existing"

--- a/.github/workflows/ci-health-alerts.yml
+++ b/.github/workflows/ci-health-alerts.yml
@@ -14,7 +14,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.id || github.run_id }}
+  # One workflow-wide group (not per-event) so the read/create/close sequences
+  # that share ci-alert issue state run serially — concurrent runs cannot
+  # duplicate an issue or close one based on stale state.
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
@@ -29,17 +32,25 @@ jobs:
     permissions:
       contents: read
       issues: write
-      actions: read
+      # The commits/{ref}/check-runs endpoint used by the red-main sweep needs
+      # the Checks read scope.
+      checks: read
     steps:
-      - name: Alert on a failed deploy or release run
+      - name: Alert on a failed or timed-out deploy or release run
         if: >-
           github.event_name == 'workflow_run' &&
-          github.event.workflow_run.conclusion == 'failure'
+          (github.event.workflow_run.conclusion == 'failure' ||
+          github.event.workflow_run.conclusion == 'timed_out')
         env:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
+          # Ensure the tracking label exists so gh issue create cannot fail on an
+          # unknown label (idempotent; the label is also provisioned as repo
+          # metadata).
+          gh label create ci-alert --color B60205 \
+            --description "Deploy/release/red-main CI health alerts" 2>/dev/null || true
           title="CI health: '$WORKFLOW_NAME' workflow is failing"
           existing="$(gh issue list --label ci-alert --state open \
             --search "$title in:title" --json number --jq '.[0].number')"
@@ -74,10 +85,18 @@ jobs:
           # Daily approximation of the "main red > 24h" signal: the sweep runs
           # once a day and refreshes (comments on) the same issue rather than
           # duplicating, so a persistently red main keeps one open issue that
-          # auto-closes on the first green sweep.
+          # auto-closes on the first fully-green sweep.
+          gh label create ci-alert --color B60205 \
+            --description "Deploy/release/red-main CI health alerts" 2>/dev/null || true
           sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')"
-          failed="$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs" \
-            --jq '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out")] | length')"
+          # per_page=100 captures every check-run for the commit in one page
+          # (this repo has well under 100). failed = completed red; incomplete =
+          # still queued/in-progress (no conclusion yet).
+          runs="$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha/check-runs?per_page=100")"
+          failed="$(printf '%s' "$runs" | \
+            jq '[.check_runs[] | select(.conclusion == "failure" or .conclusion == "timed_out")] | length')"
+          incomplete="$(printf '%s' "$runs" | \
+            jq '[.check_runs[] | select(.status != "completed")] | length')"
           title='CI health: main is red'
           existing="$(gh issue list --label ci-alert --state open \
             --search "$title in:title" --json number --jq '.[0].number')"
@@ -89,7 +108,9 @@ jobs:
               gh issue create --label ci-alert --title "$title" \
                 --body "The default branch has $failed failing check-run(s) at $sha: $commit_url"
             fi
-          elif [ -n "$existing" ]; then
+          elif [ "$incomplete" -eq 0 ] && [ -n "$existing" ]; then
+            # Only close once every check-run has completed and none failed — a
+            # commit whose checks are still running is not "recovered".
             gh issue comment "$existing" --body "main is green again at $sha. Closing."
             gh issue close "$existing"
           fi

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
       - main
+    # Re-run on title/body edits too (default types miss `edited`), so a title
+    # fixed or broken after opening is always re-validated.
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
 
 permissions:
   contents: read
@@ -14,12 +21,15 @@ concurrency:
 
 jobs:
   commitlint:
-    # Skip bot authors: Dependabot/renovate use `deps(deps):` messages whose
+    # Skip bot-authored PRs: Dependabot/renovate use `deps(deps):` messages whose
     # type is outside the allowed list and whose issue number sits after the
     # colon, so they fail the repo's custom check-task-number-rule. Gating them
-    # would red-wall the weekly dependency PRs. Human commits and PR titles must
-    # still follow `type(#NNN): summary`.
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    # would red-wall the weekly dependency PRs. Keyed on the PR author (not
+    # github.actor) so a human reopening a bot PR still skips. Human commits and
+    # PR titles must follow `type(#NNN): summary`.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'renovate[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -51,20 +61,27 @@ jobs:
         run: |
           # Install the exact Bun pinned in package.json's packageManager field,
           # then install locked deps (mirrors static-testing.yml). commitlint and
-          # its config-conventional preset resolve from bun.lock, so the repo's
-          # commitlint.config.js — including the custom check-task-number-rule —
-          # is what runs.
+          # its config-conventional preset resolve from bun.lock.
           npm install -g "$(node -p "require('./package.json').packageManager.split('+')[0]")"
           bun install --frozen-lockfile
+
+      - name: Extract the trusted base commitlint config
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        # Validate against the base branch's config, never the PR's own copy, so a
+        # PR cannot weaken the very rules it must satisfy. Written into the repo
+        # root so `extends: @commitlint/config-conventional` resolves from
+        # node_modules; .cjs keeps it CommonJS regardless of package.json type.
+        run: git show "$BASE_SHA:commitlint.config.js" > commitlint.base.config.cjs
 
       - name: Lint the PR commit range
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: bun x commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
+        run: bun x commitlint --config commitlint.base.config.cjs --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
 
       - name: Lint the PR title (squash merges use it as the commit message)
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         # Title passed via env, never interpolated into the script body.
-        run: printf '%s' "$PR_TITLE" | bun x commitlint --verbose
+        run: printf '%s' "$PR_TITLE" | bun x commitlint --config commitlint.base.config.cjs --verbose

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,70 @@
+name: commit hygiene
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    # Skip bot authors: Dependabot/renovate use `deps(deps):` messages whose
+    # type is outside the allowed list and whose issue number sits after the
+    # colon, so they fail the repo's custom check-task-number-rule. Gating them
+    # would red-wall the weekly dependency PRs. Human commits and PR titles must
+    # still follow `type(#NNN): summary`.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      CI: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the PR commit range is resolvable.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache Bun cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-
+
+      - name: Setup Bun and install dependencies
+        run: |
+          # Install the exact Bun pinned in package.json's packageManager field,
+          # then install locked deps (mirrors static-testing.yml). commitlint and
+          # its config-conventional preset resolve from bun.lock, so the repo's
+          # commitlint.config.js — including the custom check-task-number-rule —
+          # is what runs.
+          npm install -g "$(node -p "require('./package.json').packageManager.split('+')[0]")"
+          bun install --frozen-lockfile
+
+      - name: Lint the PR commit range
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bun x commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
+
+      - name: Lint the PR title (squash merges use it as the commit message)
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        # Title passed via env, never interpolated into the script body.
+        run: printf '%s' "$PR_TITLE" | bun x commitlint --verbose

--- a/.github/workflows/docker-build-canary.yml
+++ b/.github/workflows/docker-build-canary.yml
@@ -14,11 +14,13 @@ concurrency:
 
 jobs:
   canary:
-    # Catches builds broken by the outside world between PRs — upstream apk
-    # packages vanishing, registry rate-limit changes, stale base tags (#371).
-    # The host-mode PR build (CI=1 make build-out) misses the Docker/apk/registry
-    # class entirely, so this exercises the real Docker build path nightly and
-    # files an owned issue instead of surfacing as a surprise red PR.
+    # Detects builds broken by the outside world between PRs — vanished apk
+    # packages, registry rate-limit changes, stale base tags (#371). PR-time
+    # build-artifact.yml runs only when a PR is pushed and builds only the
+    # production image (`docker build --target production`); this canary runs on a
+    # schedule with no PR, and `make build` builds the FULL compose stack (Apollo,
+    # Mockoon, Playwright, MemoryLeak images) that the PR build never exercises.
+    # It files an owned issue instead of surfacing as a surprise red PR.
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
@@ -41,6 +43,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Ensure the tracking label exists so gh issue create cannot fail on an
+          # unknown label (idempotent; also provisioned as repo metadata).
+          gh label create ci-canary --color BFD4F2 \
+            --description "Nightly Docker build canary failures" 2>/dev/null || true
           title='Docker build canary failed'
           run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           existing="$(gh issue list --label ci-canary --state open \

--- a/.github/workflows/docker-build-canary.yml
+++ b/.github/workflows/docker-build-canary.yml
@@ -15,12 +15,13 @@ concurrency:
 jobs:
   canary:
     # Detects builds broken by the outside world between PRs — vanished apk
-    # packages, registry rate-limit changes, stale base tags (#371). PR-time
-    # build-artifact.yml runs only when a PR is pushed and builds only the
-    # production image (`docker build --target production`); this canary runs on a
-    # schedule with no PR, and `make build` builds the FULL compose stack (Apollo,
-    # Mockoon, Playwright, MemoryLeak images) that the PR build never exercises.
-    # It files an owned issue instead of surfacing as a surprise red PR.
+    # packages, registry rate-limit changes, stale base tags (#371). It builds
+    # every image in the compose stack — dev, prod, apollo, mockoon, playwright,
+    # k6 and memory-leak, i.e. all six Dockerfiles — plus the extracted
+    # production artifact, on a schedule with no PR, so upstream breakage in ANY
+    # image is caught early and filed as an owned issue instead of a surprise red
+    # PR. (PR-time build-artifact.yml only runs on a push and only builds the
+    # production image.)
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
@@ -32,10 +33,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build the Docker image stack
-        run: make build
+      - name: Build every image in the compose stack
+        # All three compose files + the load profile so every Dockerfile is
+        # exercised, not just the default docker-compose.yml `dev` service.
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.test.yml \
+            -f docker-compose.memory-leak.yml \
+            --profile load build
 
-      - name: Build the production artifact
+      - name: Build and extract the production artifact
         run: CI=1 make build-out
 
       - name: File or refresh the canary issue on failure

--- a/.github/workflows/docker-build-canary.yml
+++ b/.github/workflows/docker-build-canary.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-canary.yml
+++ b/.github/workflows/docker-build-canary.yml
@@ -1,0 +1,53 @@
+name: docker build canary
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    # Catches builds broken by the outside world between PRs — upstream apk
+    # packages vanishing, registry rate-limit changes, stale base tags (#371).
+    # The host-mode PR build (CI=1 make build-out) misses the Docker/apk/registry
+    # class entirely, so this exercises the real Docker build path nightly and
+    # files an owned issue instead of surfacing as a surprise red PR.
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build the Docker image stack
+        run: make build
+
+      - name: Build the production artifact
+        run: CI=1 make build-out
+
+      - name: File or refresh the canary issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title='Docker build canary failed'
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          existing="$(gh issue list --label ci-canary --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Canary still red: $run_url"
+          else
+            gh issue create --label ci-canary --title "$title" \
+              --body "Nightly Docker build canary is red: $run_url"
+          fi

--- a/.github/workflows/fuzz-testing.yml
+++ b/.github/workflows/fuzz-testing.yml
@@ -57,7 +57,9 @@ jobs:
         run: make test-fuzz
 
       - name: File or refresh the tracking issue on failure
-        if: failure()
+        # Only a genuine property failure, not a checkout/install/setup failure —
+        # otherwise a setup blip would file a false "property failure" issue.
+        if: failure() && steps.fuzz.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/fuzz-testing.yml
+++ b/.github/workflows/fuzz-testing.yml
@@ -63,6 +63,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Ensure the tracking label exists so gh issue create cannot fail on an
+          # unknown label (idempotent; test-effectiveness is provisioned already).
+          gh label create test-effectiveness --color 0E8A16 \
+            --description "Test-effectiveness gaps" 2>/dev/null || true
           title='Nightly fuzz run detected a property failure'
           run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           existing="$(gh issue list --label test-effectiveness --state open \

--- a/.github/workflows/fuzz-testing.yml
+++ b/.github/workflows/fuzz-testing.yml
@@ -1,0 +1,73 @@
+name: fuzz testing
+
+on:
+  schedule:
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  fuzz:
+    # Deep, non-PR leg of #347: the same fast-check property suites that run at
+    # 100 iterations inside unit-testing.yml, re-run here at 100000 to explore
+    # far more of the input space. It never gates a PR; a counterexample fails
+    # this run and files a tracking issue.
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      issues: write
+    env:
+      CI: 1
+      FC_NUM_RUNS: 100000
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache Bun cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-
+
+      - name: Setup Bun and install dependencies
+        run: |
+          # Install the exact Bun pinned in package.json's packageManager field,
+          # then install locked deps (mirrors static-testing.yml).
+          npm install -g "$(node -p "require('./package.json').packageManager.split('+')[0]")"
+          bun install --frozen-lockfile
+
+      - name: Run property suites at high run counts
+        id: fuzz
+        run: make test-fuzz
+
+      - name: File or refresh the tracking issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title='Nightly fuzz run detected a property failure'
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          existing="$(gh issue list --label test-effectiveness --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Fuzz run still red: $run_url"
+          else
+            gh issue create --label test-effectiveness --title "$title" \
+              --body "The nightly fast-check fuzz leg found a counterexample. See $run_url for the shrunk input."
+          fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,49 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analysis:
+    # Continuous supply-chain posture measurement (#346): runs on main push and
+    # weekly, uploads SARIF to code scanning so regressions in pinning, token
+    # permissions, or dangerous-workflow patterns surface as alerts. This is a
+    # main-branch monitor with no pull_request trigger, so it never gates a PR.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Upload the results as code-scanning SARIF.
+      security-events: write
+      # Publish results to the public OpenSSF API (publish_results: true).
+      id-token: write
+      # Read workflow-run metadata for the Scorecard checks.
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v3
+        with:
+          sarif_file: results.sarif

--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,12 @@ test-unit-server: ## Run server-side unit tests for Apollo using Jest (Node.js e
 test-unit-edge: ## Run edge-script unit tests using Jest (Node.js env, TEST_ENV=edge, target: $(TEST_DIR_EDGE))
 	$(UNIT_TESTS) TEST_ENV=edge $(JEST_BIN) $(JEST_FLAGS) $(TEST_DIR_EDGE)
 
+test-fuzz: ## Run the fast-check property suites at high run counts (FC_NUM_RUNS, default 100000) — the nightly fuzz leg of #347
+	# Coverage is disabled: this path-filtered subset would otherwise trip the
+	# global coverage threshold. The property files also run (at the default 100
+	# runs) inside test-unit-client/server; this leg only raises the run count.
+	$(UNIT_TESTS) TEST_ENV=client FC_NUM_RUNS=$${FC_NUM_RUNS:-100000} $(JEST_BIN) $(JEST_FLAGS) --coverage=false property.test
+
 test-integration: ## Run the integration layer using Jest (TEST_ENV=integration, target: tests/integration)
 	$(UNIT_TESTS) TEST_ENV=integration $(JEST_BIN) $(JEST_FLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -415,11 +415,11 @@ test-unit-server: ## Run server-side unit tests for Apollo using Jest (Node.js e
 test-unit-edge: ## Run edge-script unit tests using Jest (Node.js env, TEST_ENV=edge, target: $(TEST_DIR_EDGE))
 	$(UNIT_TESTS) TEST_ENV=edge $(JEST_BIN) $(JEST_FLAGS) $(TEST_DIR_EDGE)
 
-test-fuzz: ## Run the fast-check property suites at high run counts (FC_NUM_RUNS, default 100000) — the nightly fuzz leg of #347
-	# Coverage is disabled: this path-filtered subset would otherwise trip the
-	# global coverage threshold. The property files also run (at the default 100
-	# runs) inside test-unit-client/server; this leg only raises the run count.
-	$(UNIT_TESTS) TEST_ENV=client FC_NUM_RUNS=$${FC_NUM_RUNS:-100000} $(JEST_BIN) $(JEST_FLAGS) --coverage=false property.test
+test-fuzz: ## Run the client unit suite with the property suites at high fast-check run counts (FC_NUM_RUNS, default 100000) — the nightly fuzz leg of #347
+	# Runs the full client suite so Jest coverage and its thresholds stay
+	# enforced; FC_NUM_RUNS raises only the fast-check property suites' iteration
+	# count (other suites ignore it), turning this into the deep fuzz pass.
+	$(UNIT_TESTS) TEST_ENV=client FC_NUM_RUNS=$${FC_NUM_RUNS:-100000} $(JEST_BIN) $(JEST_FLAGS)
 
 test-integration: ## Run the integration layer using Jest (TEST_ENV=integration, target: tests/integration)
 	$(UNIT_TESTS) TEST_ENV=integration $(JEST_BIN) $(JEST_FLAGS)

--- a/bun.lock
+++ b/bun.lock
@@ -81,6 +81,7 @@
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-storybook": "^10.4.1",
         "eslint-plugin-testing-library": "^7.16.2",
+        "fast-check": "^4.9.0",
         "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
@@ -2053,6 +2054,8 @@
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "4.4.3", "get-stream": "5.2.0", "yauzl": "2.10.0" }, "optionalDependencies": { "@types/yauzl": "2.10.3" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
@@ -2979,7 +2982,7 @@
 
     "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "8.21.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
 
-    "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
@@ -3976,6 +3979,8 @@
     "istanbul-lib-report/make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "7.8.1" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "jest-changed-files/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "7.0.6", "get-stream": "6.0.1", "human-signals": "2.1.0", "is-stream": "2.0.1", "merge-stream": "2.0.0", "npm-run-path": "4.0.1", "onetime": "5.1.2", "signal-exit": "3.0.7", "strip-final-newline": "2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "jest-circus/pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
 
     "jest-config/babel-jest": ["babel-jest@30.4.1", "", { "dependencies": { "@jest/transform": "30.4.1", "@types/babel__core": "7.20.5", "babel-plugin-istanbul": "7.0.1", "babel-preset-jest": "30.4.0", "chalk": "4.1.2", "graceful-fs": "4.2.11", "slash": "3.0.0" }, "peerDependencies": { "@babel/core": "7.29.7" } }, "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw=="],
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-storybook": "^10.4.1",
     "eslint-plugin-testing-library": "^7.16.2",
+    "fast-check": "^4.9.0",
     "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",

--- a/src/test/unit/email-validation.property.test.ts
+++ b/src/test/unit/email-validation.property.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Property-based coverage for the email validators (#347).
+ *
+ * The example-based suite (email-validation.test.ts) checks a few fixed
+ * addresses; these fast-check properties fuzz the full string space to prove
+ * the validators are total (never throw, always return the documented shape)
+ * and to pin the boundary contract (missing '@' is always rejected; a
+ * well-formed address is always accepted).
+ *
+ * PR runs use 100 iterations; the nightly fuzz leg raises FC_NUM_RUNS.
+ */
+import fc from 'fast-check';
+
+import { validateEmail } from '@landing/auth-section/validations';
+import { isValidEmailFormat } from '@landing/auth-section/validations/email';
+
+const numRuns: number = Number(process.env.FC_NUM_RUNS ?? 100);
+
+// Non-empty ASCII-alphanumeric segments, guaranteed to satisfy the validator's
+// `[^\s@]+` character class (no whitespace, no '@', no '.').
+const emailSegment = fc
+  .string({ minLength: 1, maxLength: 12 })
+  .map((s: string): string => s.replace(/[^a-z0-9]/gi, ''))
+  .filter((s: string): boolean => s.length > 0);
+
+describe('email validation property tests', () => {
+  it('isValidEmailFormat never throws and always returns a boolean', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(
+          fc.string(),
+          (input: string): boolean => typeof isValidEmailFormat(input) === 'boolean'
+        ),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+
+  it('validateEmail never throws and returns true or a non-empty message', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(fc.string(), (input: string): boolean => {
+          const result: string | boolean = validateEmail(input);
+          return result === true || (typeof result === 'string' && result.length > 0);
+        }),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects any input without an "@" as invalid', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(
+          fc.string().filter((s: string): boolean => !s.includes('@')),
+          (input: string): boolean => validateEmail(input) !== true
+        ),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+
+  it('accepts a well-formed local@domain.tld address', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(
+          emailSegment,
+          emailSegment,
+          emailSegment,
+          (local: string, domain: string, tld: string): boolean => {
+            const email: string = `${local}@${domain}.${tld}`;
+            return isValidEmailFormat(email) && validateEmail(email) === true;
+          }
+        ),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/test/unit/normalize-link.property.test.ts
+++ b/src/test/unit/normalize-link.property.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Property-based coverage for `normalizeLink` (#347).
+ *
+ * Example-based tests (see normalizeLink.test.ts) pin a handful of hand-picked
+ * inputs; these fast-check properties enumerate the whole string space — the
+ * input-shape class behind the CloudFront path incidents (#226/#229/#249) —
+ * asserting the invariants hold for hostile unicode, empty/boundary strings,
+ * and arbitrary fragments.
+ *
+ * The PR unit job runs the default 100 runs (sub-second); the nightly fuzz leg
+ * (`make test-fuzz` in fuzz-testing.yml) raises FC_NUM_RUNS to 100000.
+ */
+import fc from 'fast-check';
+
+import normalizeLink from '../../features/landing/helpers/normalizeLink';
+
+const numRuns: number = Number(process.env.FC_NUM_RUNS ?? 100);
+
+describe('normalizeLink property tests', () => {
+  it('never throws and always returns a fully lowercased string', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(fc.string(), (input: string): boolean => {
+          const result: string = normalizeLink(input);
+          return typeof result === 'string' && result === result.toLowerCase();
+        }),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+
+  it('lowercases inputs that have no leading hash without altering them otherwise', () => {
+    // Scoped to inputs with no leading '#': the strip is then a no-op, so the
+    // result must equal the lowercased input. The general case only removes a
+    // single leading '#' ("##a" -> "#a"), which is why this is guarded.
+    expect(() =>
+      fc.assert(
+        fc.property(
+          fc.string().filter((s: string): boolean => !s.startsWith('#')),
+          (input: string): boolean => normalizeLink(input) === input.toLowerCase()
+        ),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+
+  it('strips exactly one leading hash, then lowercases the remainder', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(
+          fc.string().filter((s: string): boolean => !s.startsWith('#')),
+          (rest: string): boolean => normalizeLink(`#${rest}`) === rest.toLowerCase()
+        ),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+
+  it('is idempotent on generated URLs', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(fc.webUrl(), (url: string): boolean => {
+          const once: string = normalizeLink(url);
+          return normalizeLink(once) === once;
+        }),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/test/unit/password-validation.property.test.ts
+++ b/src/test/unit/password-validation.property.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Property-based coverage for `validatePassword` (#347).
+ *
+ * Fuzzes the full string space to prove the validator is total and to pin the
+ * policy boundaries: anything shorter than the minimum is always rejected, and
+ * a value that satisfies every rule is always accepted. Complements the
+ * example-based password suite.
+ *
+ * PR runs use 100 iterations; the nightly fuzz leg raises FC_NUM_RUNS.
+ */
+import fc from 'fast-check';
+
+import { validatePassword } from '@landing/auth-section/validations';
+
+const numRuns: number = Number(process.env.FC_NUM_RUNS ?? 100);
+const MIN_LENGTH = 8;
+const MAX_LENGTH = 64;
+
+describe('validatePassword property tests', () => {
+  it('never throws and returns true or a non-empty error message', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(fc.string(), (input: string): boolean => {
+          const result: string | boolean = validatePassword(input);
+          return result === true || (typeof result === 'string' && result.length > 0);
+        }),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects any value shorter than the minimum length', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(
+          fc.string().filter((s: string): boolean => s.length < MIN_LENGTH),
+          (input: string): boolean => validatePassword(input) !== true
+        ),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+
+  it('accepts any value that satisfies every rule (length, digit, uppercase)', () => {
+    expect(() =>
+      fc.assert(
+        fc.property(fc.string(), (filler: string): boolean => {
+          // 'A' → uppercase rule, '1' → digit rule, padEnd/slice → length range.
+          const password: string = `Aa1${filler}`.padEnd(MIN_LENGTH, 'x').slice(0, MAX_LENGTH);
+          return validatePassword(password) === true;
+        }),
+        { numRuns }
+      )
+    ).not.toThrow();
+  });
+});

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -37,6 +37,7 @@ test-unit-all	ci	.github/workflows/unit-testing.yml	Executed directly by the uni
 test-unit-client	ci	.github/workflows/unit-testing.yml	Executed through `make test-unit-all`, which depends on `test-unit-client`.
 test-unit-server	ci	.github/workflows/unit-testing.yml	Executed through `make test-unit-all`, which depends on `test-unit-server`.
 test-unit-edge	ci	.github/workflows/unit-testing.yml	Executed through `make test-unit-all`, which depends on `test-unit-edge`.
+test-fuzz	ci	.github/workflows/fuzz-testing.yml	Executed directly by the nightly fuzz workflow at FC_NUM_RUNS=100000.
 test-bats	ci	.github/workflows/bats-testing.yml	Executed directly by the dedicated Bats PR workflow.
 test-memory-leak	ci	.github/workflows/memory-leak-testing.yml	Executed directly by the memory leak workflow.
 memory-leak-dind	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker Compose commands.


### PR DESCRIPTION
## What & why

A second batch of **five independent `[ci-gap]` gates**, chosen so their file
footprints are disjoint (no merge conflicts between them) and every one was
re-verified against **current `main`** rather than the issue snapshots (the
issues were filed 2026‑07‑04, before #328/#330/#332/#396/#401 landed).

Each issue is one commit. Four are new workflow files; one (#347) is the only
change touching shared files (`package.json`, `bun.lock`, `Makefile`, the Bats
coverage manifest), so the commits don't step on each other.

| Issue | Gate | Runs on PR? |
| --- | --- | --- |
| #347 | fast-check property suites + nightly high-run fuzz leg | ✅ (`test-unit-client`) |
| #355 | commitlint on PR commit range + PR title | ✅ |
| #346 | OpenSSF Scorecard weekly + SARIF upload | ❌ monitoring (push‑main + schedule) |
| #371 | nightly Docker build canary + auto-filed issue | ❌ schedule |
| #365 | alert on deploy/release failure and red `main` | ❌ `workflow_run` + schedule |

## Per-issue notes

**#347 — property tests / fuzz.** `fast-check@4` devDependency. Three suites
(`normalize-link`, `email-validation`, `password-validation`) assert
total-function invariants and policy boundaries; they run at 100 iterations in
the existing unit job (the blocking PR leg) and at `FC_NUM_RUNS=100000` in the
new nightly `fuzz-testing.yml` (`make test-fuzz`), which files a tracking issue
on a counterexample. The nightly leg disables coverage so a path-filtered subset
can't trip the global threshold. *Scoped:* the CloudFront-handler fuzz the issue
mentions is deferred — #349 already pins that file's exact response shapes at
100% edge coverage; this batch delivers the validator/normalizer fuzzing and the
nightly deep leg.

**#355 — commitlint.** Bun-native (`bun x commitlint`) so the repo's custom
`check-task-number-rule` runs. Lints the PR commit range and the PR title
(squash-merge → commit message on `main`). **Bot authors are skipped** — the
weekly Dependabot `deps(deps):` PRs use a type outside the allow-list and put the
issue number after the colon, so gating them would red-wall dependency updates.

**#346 — Scorecard.** SHA-pinned `ossf/scorecard-action` + `upload-sarif`
(reusing the repo's existing CodeQL pin), `publish_results: true`. Main-branch
monitor, not a PR context.

**#371 — build canary.** Runs the real Docker build path (`make build` +
`CI=1 make build-out`) nightly; the host-mode PR build can't see the
Docker/apk/registry failure class. Files/refreshes a `ci-canary` issue on
failure. New `ci-canary` label created.

**#365 — CI-health alerts.** `workflow_run` on the `website` (deploy) and
`Generate Changelog and Create Release` workflows plus a daily sweep of the
latest `main` commit's check-runs. Files/refreshes a `ci-alert` issue and closes
it on recovery. The "red > 24h" signal is approximated by the once-daily cadence
(one refreshed issue, auto-closed on the first green sweep). New `ci-alert` label
created.

## Out of scope (deliberately)

- **Required-status-checks ruleset (#343).** Several issues say "add this context
  to the #343 ruleset". That's repository configuration applied by an admin and
  is not part of this PR — these gates land as normal checks first.
- The **monitoring workflows (#346/#365/#371 + the fuzz nightly)** have no
  `pull_request` trigger, so they cannot run on this PR; they activate on
  `main`/schedule once merged.

## Verification (local)

- `make lint` clean (ESLint, tsc, markdownlint, dependency-cruiser — 555 modules).
- `make test-unit-client` 399 tests pass (includes the property suites);
  apollo-server 8, edge 24.
- `make test-fuzz` green; `FC_NUM_RUNS` honoured.
- Full Bats suite (75 tests) green, incl. the make-target-coverage manifest
  contract for the new `test-fuzz` target.
- All five workflow YAML files parse; the `format yaml files` gate is
  non-enforcing in practice (verified across recent PRs).

Closes #347
Closes #355
Closes #346
Closes #371
Closes #365

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five independent CI gates: PR commitlint, `fast-check` property tests with a nightly fuzz leg, OpenSSF Scorecard, a nightly Docker build canary that builds the full compose stack, and CI‑health alerts. Improves test depth, commit hygiene, supply‑chain posture, and post‑merge/upstream failure detection.

- **New Features**
  - Property tests with `fast-check` for link/email/password; 100 runs on PRs; nightly fuzz at 100k via `make test-fuzz`; files/refreshes a tracking issue only on property failure; runs the full client suite so coverage/thresholds stay enforced.
  - Commit hygiene gate: lint PR commit range and title with `commitlint` against the base‑branch config; re‑checks on title edits; Dependabot/Renovate bots are skipped.
  - OpenSSF Scorecard on main push and weekly with SARIF upload; monitor‑only (not a PR gate).
  - Nightly Docker build canary builds every image across all compose files (+ load profile) and then runs `CI=1 make build-out`; files/refreshes a `ci-canary` issue (label ensured).
  - CI health alerts for failed/timed_out deploy/release runs and a red `main`; serialized; uses Checks + Actions APIs; never closes while checks are in progress and confirms the latest main run is green before closing; files/refreshes a `ci-alert` issue and auto‑closes on recovery (monitor‑only).

- **Dependencies**
  - Add dev dependency `fast-check@4`.

<sup>Written for commit b224056e071c55ac5be2b6216a6add75910d30a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

