### PR TITLE
ci(#370): digest-pin container base images and add a registry-policy lint

### DIFF
--- a/Apollo.Dockerfile
+++ b/Apollo.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23 AS base
+FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS base
 
 RUN apk add --no-cache curl=8.20.0-r0 && \
     npm install -g bun@1.3.5 typescript@5.8.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23 AS base
+FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS base
 
 RUN apk add --no-cache \
     python3=3.12.13-r0\
@@ -31,7 +31,7 @@ RUN node scripts/patchSwaggerServer.mjs && \
 # Starting from a clean base instead of inheriting `base` keeps the shipped
 # image within the docker-perf budget. `curl` is kept because the
 # docker-compose prod healthcheck (`curl -f http://…`) depends on it.
-FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23 AS production
+FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS production
 
 RUN apk add --no-cache curl=8.20.0-r0 && \
     npm install -g serve@14.2.0

--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,10 @@ lint-deps: ## Validate architecture/import boundaries with dependency-cruiser
 	node scripts/generateLocalization.mjs
 	$(PM_EXEC) $(DEPCRUISE_BIN) src pages tests --config .dependency-cruiser.js
 
-lint: lint-next lint-tsc lint-md lint-deps ## Runs all linters: ESLint, TypeScript, Markdown, and dependency-cruiser in sequence.
+lint-docker-policy: ## Enforce the registry (no Docker Hub) + digest-pin policy on every Dockerfile
+	./scripts/ci/lint-dockerfile-policy.sh
+
+lint: lint-next lint-tsc lint-md lint-deps lint-docker-policy ## Runs all linters: ESLint, TypeScript, Markdown, dependency-cruiser, and the Dockerfile registry/digest policy in sequence.
 
 # DELIBERATE DIVERGENCE FROM THE npm-tool LINT GATES (lint-next/tsc/md/deps),
 # for the same reason as lint-metrics below:

--- a/MemoryLeak.Dockerfile
+++ b/MemoryLeak.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23 AS base
+FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS base
 
 RUN apk add --no-cache \
     chromium=149.0.7827.53-r0 \

--- a/Mockoon.Dockerfile
+++ b/Mockoon.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23 AS base
+FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23@sha256:595398b0081eacda8e1c4c5b97b76cd1020e4d58a8ebcb4843b9bca1e79e7436 AS base
 
 WORKDIR /app
 

--- a/Playwright.Dockerfile
+++ b/Playwright.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.57.0-jammy
+FROM mcr.microsoft.com/playwright:v1.57.0-jammy@sha256:6aca677c27a967caf7673d108ac67ffaf8fed134f27e17b27a05464ca0ace831
 
 RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     python3=3.10.6-1~22.04.1 \

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Linting & Formatting
   make lint-tsc: runs static type checking with TypeScript
   make lint-md: lints all markdown files (excluding CHANGELOG.md) using markdownlint
   make lint-deps: validates architecture/import boundaries with dependency-cruiser
-  make lint: runs all linters (ESLint, TypeScript, markdownlint, and dependency-cruiser)
+  make lint-docker-policy: enforces the Dockerfile registry + digest-pin policy
+  make lint: runs all linters (ESLint, TypeScript, markdownlint, dependency-cruiser, Docker policy)
   make lint-metrics: runs the rust-code-analysis complexity gate (host-only, not in make lint)
   make lint-contracts: validates the pinned user-service contracts (not in make lint; needs network)
   make update-contracts: re-fetches the contracts after bumping USER_SERVICE_VERSION

--- a/scripts/ci/lint-dockerfile-policy.sh
+++ b/scripts/ci/lint-dockerfile-policy.sh
@@ -201,9 +201,10 @@ for df in "${files[@]}"; do
   # must not be treated as a pull.
   stages=" "
 
-  # Dockerfile line-continuation escape character. Defaults to backslash; a
-  # leading `# escape=` parser directive can switch it to a backtick.
-  esc='\'
+  # Dockerfile line-continuation escape character. Defaults to backslash
+  # (written as "\\" so it is a single literal backslash); a leading
+  # `# escape=` parser directive can switch it to a backtick.
+  esc="\\"
   IFS= read -r first_line <"$df" || first_line=""
   case "$(lc "$first_line")" in
     '# escape=`'* | '#escape=`'*) esc='`' ;;

--- a/scripts/ci/lint-dockerfile-policy.sh
+++ b/scripts/ci/lint-dockerfile-policy.sh
@@ -132,8 +132,10 @@ lint_from_line() {
   fi
 
   # From here `image` is an external base image reference.
-  registry="${image%%/*}"    # part before the first '/'
-  reghost="${registry%%:*}"  # strip an optional :PORT from the host
+  registry="${image%%/*}"           # part before the first '/'
+  reghost="$(lc "${registry%%:*}")" # host without :PORT, lowercased — registry
+                                    # hostnames are case-insensitive, so
+                                    # `DOCKER.IO/...` must classify as Docker Hub
   is_dockerhub=0
   if [ "$image" = "${image#*/}" ]; then
     # No registry component at all, e.g. `node:23-alpine` (Docker Hub library).

--- a/scripts/ci/lint-dockerfile-policy.sh
+++ b/scripts/ci/lint-dockerfile-policy.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Registry + digest-pin policy for every committed Dockerfile (issue #370).
+#
+# Two rules are enforced on each `FROM` that pulls an external base image:
+#
+#   1. No Docker Hub (docker.io) images — explicit *or* implicit. The repo's
+#      four repeated docker.io -> public-ECR migrations (#191, #206, #251,
+#      #253) all recurred because nothing enforced the registry repo-wide; a
+#      single conformance lint at the first incident would have prevented the
+#      other three.
+#   2. Every external base image must be digest-pinned (`@sha256:<digest>`), so
+#      a re-pushed mutable tag cannot silently change what a build runs.
+#
+# Internal build-stage references (`FROM <stage>`) and `FROM scratch` pull
+# nothing, so they are exempt. Docker treats stage names case-insensitively, so
+# the exemption does too. Dependabot's `docker` ecosystem (#364) keeps the
+# pinned digests fresh while preserving the human-readable tag.
+#
+# Usage:
+#   scripts/ci/lint-dockerfile-policy.sh [DOCKERFILE ...]
+#
+# With no arguments, every tracked *Dockerfile* is checked (via `git ls-files`).
+# Explicit paths are accepted so the policy can be unit-tested against fixtures.
+#
+# Intentionally written for POSIX-ish bash (no associative arrays / mapfile /
+# `${x,,}`) so it runs identically on the CI runner and on an older host bash.
+
+set -eu
+
+# Lowercase helper (portable substitute for bash 4's `${x,,}`).
+lc() {
+  printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]'
+}
+
+# Resolve the target file list.
+files=()
+if [ "$#" -gt 0 ]; then
+  # Explicit paths — used by the fixtures/self-tests.
+  files=("$@")
+else
+  # Default: every tracked Dockerfile. Capture git's output *and* exit status
+  # explicitly (a process substitution would hide a git failure), then fall
+  # back to a filesystem scan when git is unavailable or this is not a
+  # checkout.
+  discovered=""
+  if ! discovered="$(git ls-files '*Dockerfile*' 2>/dev/null)" || [ -z "$discovered" ]; then
+    discovered="$(find . -type f -name '*Dockerfile*' \
+      -not -path './node_modules/*' -not -path './.git/*' 2>/dev/null)"
+  fi
+  while IFS= read -r tracked; do
+    if [ -n "$tracked" ]; then
+      files+=("$tracked")
+    fi
+  done <<EOF
+$discovered
+EOF
+  # This repo always ships Dockerfiles; finding none means discovery broke, so
+  # fail loudly rather than let the gate silently pass on zero files.
+  if [ "${#files[@]}" -eq 0 ]; then
+    printf 'ERROR: no Dockerfiles found to lint (expected at least one). Is this a repository checkout?\n' >&2
+    exit 1
+  fi
+fi
+
+status=0
+violation() {
+  printf 'POLICY VIOLATION: %s\n' "$1" >&2
+  status=1
+}
+
+for df in "${files[@]}"; do
+  if [ ! -f "$df" ]; then
+    violation "file not found: $df"
+    continue
+  fi
+
+  # Space-delimited set of lowercased stage aliases declared earlier in this
+  # file (`... AS <name>`). A later `FROM <name>` references one of these and
+  # must not be treated as a pull.
+  stages=" "
+
+  # `|| [ -n "$rawline" ]` processes a final line that lacks a trailing newline.
+  while IFS= read -r rawline || [ -n "$rawline" ]; do
+    # Trim surrounding whitespace; only genuine FROM instructions are relevant
+    # (a commented `# FROM ...` line no longer starts with FROM once trimmed).
+    line="${rawline#"${rawline%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    case "$(lc "$line")" in
+      from[[:space:]]*) : ;;
+      *) continue ;;
+    esac
+
+    # Tokenise on whitespace: toks[0] == FROM.
+    read -r -a toks <<<"$line"
+
+    # Skip any leading build flags such as `--platform=linux/amd64`.
+    idx=1
+    while [ -n "${toks[$idx]:-}" ]; do
+      case "${toks[$idx]}" in
+        --*) idx=$((idx + 1)) ;;
+        *) break ;;
+      esac
+    done
+    image="${toks[$idx]:-}"
+    imgkey="$(lc "$image")"
+
+    # Locate an optional `AS <name>` stage alias.
+    asname=""
+    i=$((idx + 1))
+    count=${#toks[@]}
+    while [ "$i" -lt "$count" ]; do
+      if [ "$(lc "${toks[$i]}")" = "as" ]; then
+        asname="$(lc "${toks[$((i + 1))]:-}")"
+        break
+      fi
+      i=$((i + 1))
+    done
+
+    # Internal stage reference, `scratch`, or empty base — nothing is pulled.
+    is_stage=0
+    case "$stages" in
+      *" $imgkey "*) is_stage=1 ;;
+    esac
+    if [ -z "$image" ] || [ "$is_stage" -eq 1 ] || [ "$imgkey" = "scratch" ]; then
+      if [ -n "$asname" ]; then
+        stages="$stages$asname "
+      fi
+      continue
+    fi
+
+    # From here `image` is an external base image reference.
+    registry="${image%%/*}"    # part before the first '/'
+    reghost="${registry%%:*}"  # strip an optional :PORT from the host
+    is_dockerhub=0
+    if [ "$image" = "${image#*/}" ]; then
+      # No registry component at all, e.g. `node:23-alpine` (Docker Hub library).
+      is_dockerhub=1
+    else
+      case "$reghost" in
+        docker.io | *.docker.io)
+          # Explicitly spelled Docker Hub (docker.io / registry-1.docker.io ...).
+          is_dockerhub=1
+          ;;
+        *.* | localhost)
+          # A real registry host (has a dot) or a local registry — allowed.
+          : ;;
+        *)
+          # Single-label first component, e.g. `library/node` or `user/img` —
+          # still an implicit Docker Hub reference.
+          is_dockerhub=1
+          ;;
+      esac
+    fi
+
+    if [ "$is_dockerhub" -eq 1 ]; then
+      violation "$df: Docker Hub is forbidden; pin an explicit registry (e.g. public.ecr.aws/docker/library/...): 'FROM $image'"
+    fi
+    case "$image" in
+      *@sha256:*) : ;;
+      *) violation "$df: base image must be digest-pinned with @sha256:<digest>: 'FROM $image'" ;;
+    esac
+
+    if [ -n "$asname" ]; then
+      stages="$stages$asname "
+    fi
+  done <"$df"
+done
+
+if [ "$status" -ne 0 ]; then
+  printf '\nDockerfile registry/digest policy failed. See scripts/ci/lint-dockerfile-policy.sh for the rules.\n' >&2
+fi
+exit "$status"

--- a/scripts/ci/lint-dockerfile-policy.sh
+++ b/scripts/ci/lint-dockerfile-policy.sh
@@ -10,12 +10,21 @@
 #      single conformance lint at the first incident would have prevented the
 #      other three.
 #   2. Every external base image must be digest-pinned (`@sha256:<digest>`), so
-#      a re-pushed mutable tag cannot silently change what a build runs.
+#      a re-pushed mutable tag cannot silently change what a build runs. The
+#      digest must be a concrete 64-char lowercase hex value — an empty,
+#      malformed, or variable-valued suffix (`@sha256:`, `@sha256:${DIGEST}`)
+#      does not satisfy the pin.
 #
 # Internal build-stage references (`FROM <stage>`) and `FROM scratch` pull
 # nothing, so they are exempt. Docker treats stage names case-insensitively, so
 # the exemption does too. Dependabot's `docker` ecosystem (#364) keeps the
 # pinned digests fresh while preserving the human-readable tag.
+#
+# Multi-line `FROM` instructions are honoured: physical lines joined by the
+# Dockerfile line-continuation escape character (`\` by default, or the value of
+# a leading `# escape=` parser directive) are folded into one logical
+# instruction before the policy is applied, so a legitimately wrapped `FROM`
+# is evaluated rather than rejected.
 #
 # Usage:
 #   scripts/ci/lint-dockerfile-policy.sh [DOCKERFILE ...]
@@ -69,6 +78,118 @@ violation() {
   status=1
 }
 
+# Enforce the registry + digest policy on a single, already line-folded logical
+# instruction. Non-FROM lines are ignored. Reads and updates the file-scoped
+# `stages` alias set and the loop-scoped `df` (for messages), and records
+# failures via `violation`.
+lint_from_line() {
+  line="$1"
+  # Trim surrounding whitespace; only genuine FROM instructions are relevant
+  # (a commented `# FROM ...` line no longer starts with FROM once trimmed).
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  case "$(lc "$line")" in
+    from[[:space:]]*) : ;;
+    *) return 0 ;;
+  esac
+
+  # Tokenise on whitespace: toks[0] == FROM.
+  read -r -a toks <<<"$line"
+
+  # Skip any leading build flags such as `--platform=linux/amd64`.
+  idx=1
+  while [ -n "${toks[$idx]:-}" ]; do
+    case "${toks[$idx]}" in
+      --*) idx=$((idx + 1)) ;;
+      *) break ;;
+    esac
+  done
+  image="${toks[$idx]:-}"
+  imgkey="$(lc "$image")"
+
+  # Locate an optional `AS <name>` stage alias.
+  asname=""
+  i=$((idx + 1))
+  count=${#toks[@]}
+  while [ "$i" -lt "$count" ]; do
+    if [ "$(lc "${toks[$i]}")" = "as" ]; then
+      asname="$(lc "${toks[$((i + 1))]:-}")"
+      break
+    fi
+    i=$((i + 1))
+  done
+
+  # Internal stage reference, `scratch`, or empty base — nothing is pulled.
+  is_stage=0
+  case "$stages" in
+    *" $imgkey "*) is_stage=1 ;;
+  esac
+  if [ -z "$image" ] || [ "$is_stage" -eq 1 ] || [ "$imgkey" = "scratch" ]; then
+    if [ -n "$asname" ]; then
+      stages="$stages$asname "
+    fi
+    return 0
+  fi
+
+  # From here `image` is an external base image reference.
+  registry="${image%%/*}"    # part before the first '/'
+  reghost="${registry%%:*}"  # strip an optional :PORT from the host
+  is_dockerhub=0
+  if [ "$image" = "${image#*/}" ]; then
+    # No registry component at all, e.g. `node:23-alpine` (Docker Hub library).
+    is_dockerhub=1
+  else
+    case "$reghost" in
+      docker.io | *.docker.io)
+        # Explicitly spelled Docker Hub (docker.io / registry-1.docker.io ...).
+        is_dockerhub=1
+        ;;
+      *.* | localhost)
+        # A real registry host (has a dot) or a local registry — allowed.
+        : ;;
+      *)
+        # A single-label first component is an implicit Docker Hub reference
+        # (`library/node`, `user/img`) UNLESS it carries a port
+        # (`registry:5000/img`), which only ever denotes an explicit registry
+        # host — Docker Hub short forms never contain a ':' before the first '/'.
+        case "$registry" in
+          *:*) : ;;
+          *) is_dockerhub=1 ;;
+        esac
+        ;;
+    esac
+  fi
+
+  if [ "$is_dockerhub" -eq 1 ]; then
+    violation "$df: Docker Hub is forbidden; pin an explicit registry (e.g. public.ecr.aws/docker/library/...): 'FROM $image'"
+  fi
+
+  case "$image" in
+    *@sha256:*)
+      # The digest is the final `@sha256:` component; require a concrete
+      # 64-char lowercase hex value so an empty/variable/short suffix cannot
+      # satisfy the pin.
+      digest="${image##*@sha256:}"
+      case "$digest" in
+        "" | *[!0-9a-f]*)
+          violation "$df: @sha256 digest must be exactly 64 lowercase hex characters: 'FROM $image'" ;;
+        *)
+          if [ "${#digest}" -ne 64 ]; then
+            violation "$df: @sha256 digest must be exactly 64 lowercase hex characters: 'FROM $image'"
+          fi
+          ;;
+      esac
+      ;;
+    *)
+      violation "$df: base image must be digest-pinned with @sha256:<digest>: 'FROM $image'" ;;
+  esac
+
+  if [ -n "$asname" ]; then
+    stages="$stages$asname "
+  fi
+  return 0
+}
+
 for df in "${files[@]}"; do
   if [ ! -f "$df" ]; then
     violation "file not found: $df"
@@ -80,91 +201,49 @@ for df in "${files[@]}"; do
   # must not be treated as a pull.
   stages=" "
 
-  # `|| [ -n "$rawline" ]` processes a final line that lacks a trailing newline.
+  # Dockerfile line-continuation escape character. Defaults to backslash; a
+  # leading `# escape=` parser directive can switch it to a backtick.
+  esc='\'
+  IFS= read -r first_line <"$df" || first_line=""
+  case "$(lc "$first_line")" in
+    '# escape=`'* | '#escape=`'*) esc='`' ;;
+  esac
+
+  # Fold FROM line-continuations into a single logical instruction, then lint
+  # it. Only FROM instructions are folded — every other line (comments, RUN,
+  # etc.) is passed through verbatim so a trailing escape elsewhere can never
+  # merge a following FROM out of sight. `|| [ -n "$rawline" ]` processes a
+  # final line that lacks a trailing newline.
+  pending=""
   while IFS= read -r rawline || [ -n "$rawline" ]; do
-    # Trim surrounding whitespace; only genuine FROM instructions are relevant
-    # (a commented `# FROM ...` line no longer starts with FROM once trimmed).
-    line="${rawline#"${rawline%%[![:space:]]*}"}"
-    line="${line%"${line##*[![:space:]]}"}"
-    case "$(lc "$line")" in
-      from[[:space:]]*) : ;;
-      *) continue ;;
-    esac
-
-    # Tokenise on whitespace: toks[0] == FROM.
-    read -r -a toks <<<"$line"
-
-    # Skip any leading build flags such as `--platform=linux/amd64`.
-    idx=1
-    while [ -n "${toks[$idx]:-}" ]; do
-      case "${toks[$idx]}" in
-        --*) idx=$((idx + 1)) ;;
-        *) break ;;
-      esac
-    done
-    image="${toks[$idx]:-}"
-    imgkey="$(lc "$image")"
-
-    # Locate an optional `AS <name>` stage alias.
-    asname=""
-    i=$((idx + 1))
-    count=${#toks[@]}
-    while [ "$i" -lt "$count" ]; do
-      if [ "$(lc "${toks[$i]}")" = "as" ]; then
-        asname="$(lc "${toks[$((i + 1))]:-}")"
-        break
-      fi
-      i=$((i + 1))
-    done
-
-    # Internal stage reference, `scratch`, or empty base — nothing is pulled.
-    is_stage=0
-    case "$stages" in
-      *" $imgkey "*) is_stage=1 ;;
-    esac
-    if [ -z "$image" ] || [ "$is_stage" -eq 1 ] || [ "$imgkey" = "scratch" ]; then
-      if [ -n "$asname" ]; then
-        stages="$stages$asname "
+    if [ -n "$pending" ]; then
+      stripped="${rawline%"$esc"}"
+      pending="$pending $stripped"
+      if [ "$stripped" = "$rawline" ]; then
+        # This physical line has no trailing escape: the FROM is complete.
+        lint_from_line "$pending"
+        pending=""
       fi
       continue
     fi
-
-    # From here `image` is an external base image reference.
-    registry="${image%%/*}"    # part before the first '/'
-    reghost="${registry%%:*}"  # strip an optional :PORT from the host
-    is_dockerhub=0
-    if [ "$image" = "${image#*/}" ]; then
-      # No registry component at all, e.g. `node:23-alpine` (Docker Hub library).
-      is_dockerhub=1
-    else
-      case "$reghost" in
-        docker.io | *.docker.io)
-          # Explicitly spelled Docker Hub (docker.io / registry-1.docker.io ...).
-          is_dockerhub=1
-          ;;
-        *.* | localhost)
-          # A real registry host (has a dot) or a local registry — allowed.
-          : ;;
-        *)
-          # Single-label first component, e.g. `library/node` or `user/img` —
-          # still an implicit Docker Hub reference.
-          is_dockerhub=1
+    stripped="${rawline%"$esc"}"
+    if [ "$stripped" != "$rawline" ]; then
+      trimmed="${rawline#"${rawline%%[![:space:]]*}"}"
+      case "$(lc "$trimmed")" in
+        from[[:space:]]*)
+          # A wrapped FROM — start accumulating its continuation.
+          pending="$stripped"
+          continue
           ;;
       esac
     fi
-
-    if [ "$is_dockerhub" -eq 1 ]; then
-      violation "$df: Docker Hub is forbidden; pin an explicit registry (e.g. public.ecr.aws/docker/library/...): 'FROM $image'"
-    fi
-    case "$image" in
-      *@sha256:*) : ;;
-      *) violation "$df: base image must be digest-pinned with @sha256:<digest>: 'FROM $image'" ;;
-    esac
-
-    if [ -n "$asname" ]; then
-      stages="$stages$asname "
-    fi
+    lint_from_line "$rawline"
   done <"$df"
+  # A FROM left dangling on a trailing continuation (malformed, but still lint
+  # what we have rather than skip it silently).
+  if [ -n "$pending" ]; then
+    lint_from_line "$pending"
+  fi
 done
 
 if [ "$status" -ne 0 ]; then

--- a/src/test/load/Dockerfile
+++ b/src/test/load/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-alpine3.22 AS builder
+FROM public.ecr.aws/docker/library/golang:1.25.11-alpine3.22@sha256:65b4400aee0927412e9ed791a11893273a49d55df24841f7599660fb80dae464 AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ RUN xk6 build \
     --with github.com/grafana/xk6-exec@v0.3.0  \
     --with github.com/avitalique/xk6-file@v1.4.0
     
-FROM alpine:3.21
+FROM public.ecr.aws/docker/library/alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 COPY --from=builder /app/k6 /bin/
 

--- a/tests/bats/lint_dockerfile_policy.bats
+++ b/tests/bats/lint_dockerfile_policy.bats
@@ -4,6 +4,16 @@
 # policy gate (issue #370). Exercises the parser's edge cases directly against
 # throwaway Dockerfile fixtures so a regression in the policy logic is caught
 # without a container build.
+#
+# Scenario-class coverage (agents.md Step 2/3):
+#   - Positive / happy path: compliant explicit-registry + digest-pinned,
+#     multi-line, scratch, --platform, and port-registry FROMs pass.
+#   - Negative / error: Docker Hub (implicit, explicit, uppercase-host),
+#     unpinned, and empty/variable/short/wrong-length/uppercase digests fail.
+#   - Boundary / edge (empty, null, missing data): a no-FROM file passes; a
+#     missing file path is reported and fails.
+#   Not applicable: Loading, retry, timeout, and error (async) states — the
+#   linter is a synchronous local-file CLI with no async boundary.
 
 load './test_helper.bash'
 
@@ -109,6 +119,13 @@ lint_fixture() {
   [[ "$output" == *"Docker Hub is forbidden"* ]]
 }
 
+@test "an uppercase-host Docker Hub reference is rejected (hosts are case-insensitive)" {
+  write_fixture "FROM DOCKER.IO/library/node@sha256:$HEX64"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Docker Hub is forbidden"* ]]
+}
+
 # --- digest pinning must be a concrete 64-char hex value -------------------
 
 @test "an unpinned explicit-registry image is rejected" {
@@ -151,4 +168,18 @@ lint_fixture() {
   lint_fixture
   [ "$status" -eq 1 ]
   [[ "$output" == *"64 lowercase hex"* ]]
+}
+
+# --- boundary / edge: empty and missing inputs -----------------------------
+
+@test "a Dockerfile with no FROM instruction passes" {
+  write_fixture "# a Dockerfile with only a comment, no FROM instruction" "RUN true"
+  lint_fixture
+  [ "$status" -eq 0 ]
+}
+
+@test "a missing Dockerfile path is reported and fails" {
+  run bash "$LINTER" "$BATS_TEST_TMPDIR/does-not-exist.Dockerfile"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"file not found"* ]]
 }

--- a/tests/bats/lint_dockerfile_policy.bats
+++ b/tests/bats/lint_dockerfile_policy.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+#
+# Coverage for scripts/ci/lint-dockerfile-policy.sh — the registry + digest-pin
+# policy gate (issue #370). Exercises the parser's edge cases directly against
+# throwaway Dockerfile fixtures so a regression in the policy logic is caught
+# without a container build.
+
+load './test_helper.bash'
+
+setup() {
+  LINTER="$PROJECT_ROOT/scripts/ci/lint-dockerfile-policy.sh"
+  FIXTURE="$BATS_TEST_TMPDIR/Dockerfile.fixture"
+  # A concrete 64-char lowercase hex digest for the compliant fixtures.
+  HEX64="deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+}
+
+# Write $2.. as the fixture body (each arg is one line).
+write_fixture() {
+  printf '%s\n' "$@" > "$FIXTURE"
+}
+
+lint_fixture() {
+  run bash "$LINTER" "$FIXTURE"
+}
+
+# --- the real repository must satisfy its own policy -----------------------
+
+@test "every tracked Dockerfile in the repo passes the policy" {
+  run bash "$LINTER"
+  [ "$status" -eq 0 ]
+}
+
+# --- compliant references pass ---------------------------------------------
+
+@test "an explicit-registry, digest-pinned image passes" {
+  write_fixture "FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23@sha256:$HEX64"
+  lint_fixture
+  [ "$status" -eq 0 ]
+}
+
+@test "scratch, --platform flags, and lowercase from/as are accepted" {
+  write_fixture \
+    "FROM --platform=linux/amd64 public.ecr.aws/docker/library/golang:1.24@sha256:$HEX64 AS build" \
+    "from build as final" \
+    "FROM scratch"
+  lint_fixture
+  [ "$status" -eq 0 ]
+}
+
+@test "a single-label registry host with a port is treated as an explicit registry" {
+  write_fixture "FROM registry.internal:5000/app@sha256:$HEX64"
+  lint_fixture
+  [ "$status" -eq 0 ]
+  write_fixture "FROM myregistry:5000/team/app@sha256:$HEX64"
+  lint_fixture
+  [ "$status" -eq 0 ]
+}
+
+# --- multi-line FROM continuations -----------------------------------------
+
+@test "a compliant multi-line FROM is folded and accepted" {
+  write_fixture \
+    "FROM \\" \
+    "  public.ecr.aws/docker/library/node:24@sha256:$HEX64 \\" \
+    "  AS base" \
+    "FROM base"
+  lint_fixture
+  [ "$status" -eq 0 ]
+}
+
+@test "a non-compliant multi-line FROM is still rejected" {
+  write_fixture \
+    "FROM \\" \
+    "  node:23-alpine"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Docker Hub is forbidden"* ]]
+}
+
+@test "a trailing-backslash comment does not swallow a following FROM" {
+  write_fixture \
+    "# a comment ending in a backslash \\" \
+    "FROM node:23"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Docker Hub is forbidden"* ]]
+}
+
+# --- Docker Hub is forbidden (explicit and implicit) -----------------------
+
+@test "an implicit Docker Hub library image is rejected" {
+  write_fixture "FROM node:23-alpine"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Docker Hub is forbidden"* ]]
+}
+
+@test "an explicit docker.io reference is rejected even when digest-pinned" {
+  write_fixture "FROM docker.io/library/node:24@sha256:$HEX64"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Docker Hub is forbidden"* ]]
+}
+
+@test "a single-label user/image reference is rejected as implicit Docker Hub" {
+  write_fixture "FROM library/node@sha256:$HEX64"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Docker Hub is forbidden"* ]]
+}
+
+# --- digest pinning must be a concrete 64-char hex value -------------------
+
+@test "an unpinned explicit-registry image is rejected" {
+  write_fixture "FROM public.ecr.aws/docker/library/node:24"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"must be digest-pinned"* ]]
+}
+
+@test "an empty @sha256 suffix is rejected" {
+  write_fixture "FROM public.ecr.aws/docker/library/node:24@sha256:"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"64 lowercase hex"* ]]
+}
+
+@test "a variable-valued @sha256 suffix is rejected" {
+  write_fixture 'FROM public.ecr.aws/docker/library/node:24@sha256:${DIGEST}'
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"64 lowercase hex"* ]]
+}
+
+@test "a short/malformed @sha256 digest is rejected" {
+  write_fixture "FROM public.ecr.aws/docker/library/node:24@sha256:abc123"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"64 lowercase hex"* ]]
+}
+
+@test "a wrong-length all-hex @sha256 digest is rejected" {
+  write_fixture "FROM public.ecr.aws/docker/library/node:24@sha256:${HEX64}ab"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"64 lowercase hex"* ]]
+}
+
+@test "an uppercase-hex @sha256 digest is rejected" {
+  write_fixture "FROM public.ecr.aws/docker/library/node:24@sha256:DEADBEEFdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  lint_fixture
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"64 lowercase hex"* ]]
+}

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -95,3 +95,4 @@ test-load	bats	tests/bats/makefile_targets.bats	Validated as an alias that runs 
 test-load-swagger	bats	tests/bats/makefile_targets.bats	Validated as an alias that runs the load-tests-swagger target with stubbed K6 commands.
 pr-comments	bats	tests/bats/makefile_targets.bats	Validated with a stubbed get-pr-comments.sh helper and PR/FORMAT argument dispatch.
 lint-metrics	bats	tests/bats/makefile_targets.bats	Validated host-only: ensure-rca.sh provisioning (idempotent) plus lint-metrics.sh policy enforcement against the committed policy with a stubbed analyzer.
+lint-docker-policy	ci	.github/workflows/static-testing.yml	Executed through `make lint`, which depends on `lint-docker-policy`.


### PR DESCRIPTION
## Description

Implements ci-gap issue **#370** — _Digest-pin container base images and add a registry-policy lint_.

Two parts:

1. **Digest-pin every external base image** across all six Dockerfiles, keeping the human-readable
   tag alongside the immutable `@sha256:` digest so a re-pushed mutable tag can no longer silently
   change what a build runs:
   - `Dockerfile` (base + production stages), `Apollo.Dockerfile`, `Mockoon.Dockerfile`,
     `MemoryLeak.Dockerfile` → `public.ecr.aws/docker/library/node:24.18.0-alpine3.23@sha256:…`
   - `Playwright.Dockerfile` → `mcr.microsoft.com/playwright:v1.57.0-jammy@sha256:…`
   - `src/test/load/Dockerfile` → **migrated off Docker Hub** (`golang`/`alpine` were bare
     `docker.io`-implied references) onto `public.ecr.aws/docker/library/{golang,alpine}@sha256:…`
   - Internal multi-stage references (`FROM base AS build`, `FROM base AS final`) are intentionally
     left unpinned — they pull nothing.

2. **`scripts/ci/lint-dockerfile-policy.sh`** — a repo-wide conformance gate wired into `make lint`
   (and therefore run on every PR by `static-testing.yml`). It fails when any `FROM` that pulls an
   external image either (a) resolves to Docker Hub — explicit `docker.io/…` or implicit
   `node:…`/`user/img` — or (b) is not digest-pinned. Internal build stages and `FROM scratch` are
   exempt. The script takes optional file arguments so it can be unit-tested against fixtures.

The `make lint` aggregate and the bats make-target coverage manifest
(`tests/bats/make-target-coverage.tsv`) are updated for the new `lint-docker-policy` target.

## Related Issue

Closes #370.

## Motivation and Context

The registry/base-image incident ledger shows the same `docker.io` → public-ECR fix applied **four
separate times** (#191, #206, #251, #253) because nothing enforced the registry policy repo-wide —
a one-shot conformance lint at the first incident would have prevented the other three. Separately,
every `FROM` used a mutable tag, so a re-pushed upstream tag could silently change what every build
runs (OpenSSF Scorecard Pinned-Dependencies: 0/9 images digest-pinned). This change closes both
gaps with a single always-on lint plus one-time digest pinning, and is deliberately **not**
path-filtered (per-file path filters are exactly what let the docker.io fix recur file-by-file).

Dependabot's `docker` ecosystem (#364) keeps the pinned digests fresh while preserving the tag.

## How Has This Been Tested?

- `CI=1 make lint` — green (ESLint, tsc, markdownlint, dependency-cruiser, **and the new
  `lint-docker-policy`**).
- `make test-bats` — full suite green (86 tests), including the make-target coverage-manifest
  completeness contract that now accounts for `lint-docker-policy`.
- The lint script was exercised directly: it **passes** on the pinned repo and **fails** with the
  expected messages on negative fixtures (`FROM node:23-alpine`, explicit `docker.io/…`, unpinned
  explicit-registry, implicit `user/img`), and correctly exempts internal stages, `FROM scratch`,
  `--platform` flags, and lowercase `from`/`as`.
- Every pinned digest was verified to resolve **by digest** against its registry (HTTP 200 for
  node, golang, alpine on `public.ecr.aws` and playwright on `mcr.microsoft.com`), so `docker pull`
  in every build workflow succeeds. The pins are the current multi-arch index digests of the same
  tags, so image contents are unchanged and the `dockerfile-performance` size/perf budgets are
  unaffected; the `golang`/`alpine` registry migration is a same-content Docker Hub → public-ECR
  mirror swap.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018D6kkMidvWxkrBczfkutmk)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Digest-pinned all external Dockerfile base images and added a repo-wide lint that blocks Docker Hub and requires `@sha256` pins, now with stronger parsing and host classification. Implements #370 to prevent tag drift and enforce the registry policy on every PR.

- **New Features**
  - Pinned all external `FROM` images across `Dockerfile` (base, production), `Apollo.Dockerfile`, `Mockoon.Dockerfile`, `MemoryLeak.Dockerfile`, `Playwright.Dockerfile`, and `src/test/load/Dockerfile`.
  - Migrated load-test bases to `public.ecr.aws/docker/library/{golang,alpine}`.
  - Added `scripts/ci/lint-dockerfile-policy.sh` and wired into `make lint` as `lint-docker-policy`; forbids Docker Hub (explicit or implicit) and requires `@sha256` pins. Exempts internal stages and `FROM scratch`.
  - Hardened the lint: enforce exactly 64 lowercase-hex digests, fold multi-line `FROM` (honors `# escape=`), treat `registry:PORT/...` as an explicit registry, and classify registry hosts case-insensitively to reject `DOCKER.IO/...`. Added `tests/bats/lint_dockerfile_policy.bats` with uppercase-host and boundary coverage.
  - Updated `Makefile`, `README.md`, and `tests/bats/make-target-coverage.tsv` for the new policy gate.

- **Bug Fixes**
  - Fixed shellcheck SC1003 in the linter by setting the default escape as `esc="\\""`; behavior unchanged.

<sup>Written for commit 7c6f94375241a90df49b99c4609ef4f0fe52d6b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

