### PR TITLE
ci(#350): gate the Mockoon mock against the committed OpenAPI contract

### DIFF
--- a/.claude/skills/contract-testing-workflow/SKILL.md
+++ b/.claude/skills/contract-testing-workflow/SKILL.md
@@ -22,6 +22,8 @@ on `raw.githubusercontent.com` being reachable.
 
 ```bash
 make lint-contracts    # the gate (needs network — see below)
+make test-contract     # the Mockoon mock still matches that contract (#350)
+make lint-openapi      # advisory: is the pin itself behind upstream? (#350)
 make update-contracts  # re-fetch after bumping the pin, then commit the diff
 ```
 
@@ -111,6 +113,41 @@ normalizes both sides identically, that deletion would pass silently while
 mutating the committed contract. This is a documented transformation at the
 single point the document enters the repo — not a way to hide findings. If you
 add another normalization, say why in the code and expect to justify it in review.
+
+## The mock is gated too (#350)
+
+`lint-contracts` proves the committed artifacts match the pin. It says nothing
+about whether the **mock built from them** still behaves like the contract, and
+the whole Playwright suite runs against that mock.
+
+`make test-contract` closes that gap. The `TEST_ENV=contract` layer
+(`tests/contract/**/*.contract.test.ts`) boots Mockoon in-process from
+`contracts/user-service/openapi.json` and asserts, per documented operation:
+the status served is documented, the body's media type is declared, the body
+validates against that media type's schema, and the body carries **no property
+the schema never declares**.
+
+That last rule is stricter than OpenAPI's default on purpose, and it is
+load-bearing: upstream puts `required` on the _array_ schema of `GET /api/users`
+instead of on its `items`, so ajv alone accepts a response with every property
+renamed. Do not "fix" a red run by dropping it.
+
+| Symptom                              | Cause                                      | Fix                                                          |
+| ------------------------------------ | ------------------------------------------ | ------------------------------------------------------------ |
+| `[undeclared-property]`              | the mock serves a field the contract lacks | the contract is authoritative — refresh it, or fix the mock  |
+| `[schema-violation]`                 | Mockoon cannot generate a conforming value | usually a pin bump adding a constraint; check the new schema |
+| `[undocumented-status]`              | Mockoon's first-declared response moved    | a response was reordered or removed upstream                 |
+| `@mockoon/commons… matches the CLI…` | the two Mockoon pins drifted               | move `Mockoon.Dockerfile` **and** `package.json` together    |
+
+Seed a defect only into a **temporary copy** of the contract, never into the
+committed file — `lint-contracts` guards it, and
+`parity-detects-drift.contract.test.ts` already does this properly.
+
+`make lint-openapi` answers the other question: is the pin itself behind? It
+runs a pinned, SHA256-verified `oasdiff` against the newest upstream **release**
+and is **advisory** — the nightly `openapi-drift.yml` files an `api-contract`
+tracking issue rather than failing a check, because upstream moving on is not a
+PR author's fault. Acting on that issue is a normal pin bump (see above).
 
 ## Related guides
 

--- a/.claude/skills/contract-testing-workflow/SKILL.md
+++ b/.claude/skills/contract-testing-workflow/SKILL.md
@@ -132,12 +132,21 @@ load-bearing: upstream puts `required` on the _array_ schema of `GET /api/users`
 instead of on its `items`, so ajv alone accepts a response with every property
 renamed. Do not "fix" a red run by dropping it.
 
-| Symptom                              | Cause                                      | Fix                                                          |
-| ------------------------------------ | ------------------------------------------ | ------------------------------------------------------------ |
-| `[undeclared-property]`              | the mock serves a field the contract lacks | the contract is authoritative — refresh it, or fix the mock  |
-| `[schema-violation]`                 | Mockoon cannot generate a conforming value | usually a pin bump adding a constraint; check the new schema |
-| `[undocumented-status]`              | Mockoon's first-declared response moved    | a response was reordered or removed upstream                 |
-| `@mockoon/commons… matches the CLI…` | the two Mockoon pins drifted               | move `Mockoon.Dockerfile` **and** `package.json` together    |
+Reading a red run:
+
+- **`[undeclared-property]`** — the mock serves a field the contract does not
+  declare. The contract is authoritative: refresh it, or fix the mock.
+- **`[schema-violation]`** — Mockoon cannot generate a value the schema accepts.
+  Usually a pin bump that added a constraint; read the new schema.
+- **`[undocumented-status]`** — Mockoon's first-declared response moved, i.e. a
+  response was reordered or removed upstream.
+- **`[undocumented-media-type]`** — the status no longer declares the media type
+  the mock serves.
+- **`@mockoon/commons… matches the CLI…`** — the two Mockoon pins drifted. Move
+  `Mockoon.Dockerfile` and `package.json` together, in the same commit.
+- **`unsupportedResponseConstructs`** — upstream introduced a `$ref` or a
+  composed schema (`allOf`, `oneOf`, `prefixItems`, …). Extend the parity rules;
+  never extend the exemption list.
 
 Seed a defect only into a **temporary copy** of the contract, never into the
 committed file — `lint-contracts` guards it, and

--- a/.claude/skills/testing-workflow/SKILL.md
+++ b/.claude/skills/testing-workflow/SKILL.md
@@ -40,6 +40,7 @@ one row.
 | Apollo resolvers, server-side logic   | Server unit (node)         | `make test-unit-server`   |
 | Both unit layers at once              | All unit                   | `make test-unit-all`      |
 | Cross-layer API/flow wiring           | Integration                | `make test-integration`   |
+| The Mockoon mock, or the OpenAPI pin  | Contract parity            | `make test-contract`      |
 | A user-facing flow, end to end        | E2E (Playwright + Mockoon) | `make test-e2e`           |
 | Rendered UI or styling                | Visual regression          | `make test-visual`        |
 | Reviewed UI change, refresh baselines | Visual snapshots           | `make test-visual-update` |
@@ -54,15 +55,23 @@ Second variants and the CI-phase aliases (`make ci-test`, `make ci-test-prod`,
 
 ## Jest env selection
 
-The three unit-style suites share one Jest install and switch on `TEST_ENV`:
+The Jest-based suites share one Jest install and switch on `TEST_ENV`:
 
 - `TEST_ENV=client` — jsdom env for components, hooks, and pure client logic.
   Specs: `src/test/testing-library/**/*.test.tsx` and `src/test/unit/**/*.test.ts`.
 - `TEST_ENV=server` — node env for Apollo resolvers and server-side logic.
   Specs: `src/test/apollo-server/**/*.test.ts`.
+- `TEST_ENV=edge` — node env for the deployed edge scripts under `scripts/`.
+  Specs: `src/test/edge/**/*.test.ts`, pinned at 100% per-file coverage.
 - `TEST_ENV=integration` — jsdom env with the real Fetch API (via
   `tests/integration/jsdom-fetch.environment.js`) for the cross-layer integration
-  suite under `tests/integration`.
+  suite under `tests/integration`. Enforces a global 100% coverage sweep over
+  `src/`, so put helpers under `tests/`, never under `src/`.
+- `TEST_ENV=contract` — node env for the mock-vs-OpenAPI parity layer under
+  `tests/contract` (#350). It boots Mockoon in-process from
+  `contracts/user-service/openapi.json`; see
+  [contract-testing-workflow](../contract-testing-workflow/SKILL.md) for how to
+  read a failure.
 
 Use the `make` targets above rather than setting `TEST_ENV` by hand; they wire
 it for you. Unit suites run locally WITHOUT Docker when prefixed with `CI=1`

--- a/.github/workflows/contract-parity-testing.yml
+++ b/.github/workflows/contract-parity-testing.yml
@@ -1,0 +1,60 @@
+name: contract parity testing
+
+on:
+  pull_request:
+    # No paths filter. The obvious filter would be the Mockoon data file, the
+    # swagger e2e utils and the baseline — but the gate also depends on
+    # jest.config.ts, package.json/bun.lock (the pinned Mockoon libraries) and
+    # its own harness, so a narrow filter would let a PR that breaks the gate
+    # merge with the gate never running. This repo has twice widened a paths
+    # filter for exactly that reason (see link-check.yml). A path-filtered
+    # REQUIRED check also never reports on non-matching PRs, leaving them
+    # permanently pending.
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mock-contract-parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache Bun cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-
+
+      - name: Setup Bun and install dependencies
+        run: |
+          # Install the exact Bun pinned in package.json's packageManager field,
+          # so the version is declared in exactly one place. Corepack does not
+          # manage Bun, so it is installed globally via `npm install -g`.
+          npm install -g "$(node -p "require('./package.json').packageManager.split('+')[0]")"
+          bun install --frozen-lockfile
+
+      # Blocking by design: this is the leg that proves the Mockoon mock the e2e
+      # suite runs against still matches the committed user-service contract.
+      # Fully hermetic — Mockoon is booted in-process from the committed OpenAPI
+      # document, so there is no network call and no container to flake.
+      - name: Run mock-vs-contract parity tests
+        run: make ci-test-contract

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -70,8 +70,14 @@ jobs:
           # Fail rather than guess: a `gh issue list` that errors (rate limit,
           # API blip) writes nothing to stdout, which reads as "no tracking issue
           # exists" and would file a duplicate every night it happens.
-          if ! open_issues="$(gh issue list --label api-contract --state open --limit 100 \
-            --json number,title)"; then
+          # The `--search` phrase only NARROWS the candidate set (a quoted string
+          # is a phrase match, not the OR-of-terms a bare search does); the jq
+          # exact-title comparison below stays the authority. Narrowing matters:
+          # a plain `--limit` window would stop finding this gate's own issue
+          # once enough other open api-contract issues accumulate, and every
+          # breaking run would then open a duplicate.
+          if ! open_issues="$(gh issue list --label api-contract --state open --limit 200 \
+            --search "\"$title\" in:title" --json number,title)"; then
             echo "::error::could not list open api-contract issues; not filing a possible duplicate"
             exit 1
           fi
@@ -92,8 +98,8 @@ jobs:
           title='Upstream OpenAPI drift in the pinned user-service contract'
           # A failed list here is harmless (nothing gets closed), so it only
           # warns — unlike the filing step, where it would create a duplicate.
-          open_issues="$(gh issue list --label api-contract --state open --limit 100 \
-            --json number,title)" || open_issues='[]'
+          open_issues="$(gh issue list --label api-contract --state open --limit 200 \
+            --search "\"$title\" in:title" --json number,title)" || open_issues='[]'
           existing="$(printf '%s' "$open_issues" |
             jq -r --arg title "$title" 'map(select(.title == $title)) | .[0].number // empty')"
           if [ -n "$existing" ]; then

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -1,0 +1,83 @@
+name: openapi drift
+
+on:
+  schedule:
+    - cron: '15 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # cancel-in-progress: false — this workflow mutates shared state (a tracking
+  # issue), so a superseding run must never abort one mid-write.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  upstream-drift:
+    # Advisory by design. Upstream moving on is not a pull request author's
+    # fault, so breaking drift files a tracking issue instead of turning a check
+    # red. The blocking contract leg is `contract parity testing`.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Compare the committed baseline against the newest upstream release
+        id: drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The script is invoked directly rather than through `make
+          # lint-openapi` (the equivalent human-facing target): GNU make collapses
+          # every recipe failure to its own exit 2, and this leg depends on the
+          # script's three-way code so a network outage is never published as an
+          # API change. 0 = clean, 1 = breaking drift, anything higher = the check
+          # could not run. Only exit 1 is advisory; a broken gate must be visible,
+          # so it fails the workflow.
+          set +e
+          bash scripts/ci/openapi-drift.sh
+          status=$?
+          set -e
+          if [ "$status" -gt 1 ]; then
+            echo "::error::the upstream drift check could not run (exit $status)"
+            exit "$status"
+          fi
+          echo "drift=$status" >>"$GITHUB_OUTPUT"
+
+      - name: File or refresh the tracking issue on breaking drift
+        if: steps.drift.outputs.drift == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # `api-contract` is an existing repository label; `gh issue create
+          # --label <unknown>` errors and would silently drop the report.
+          title='Upstream OpenAPI drift: the pinned user-service contract is behind'
+          existing="$(gh issue list --label api-contract --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file reports/openapi-drift.md
+          else
+            gh issue create --label api-contract --title "$title" \
+              --body-file reports/openapi-drift.md
+          fi
+
+      - name: Close the tracking issue once the baseline is current again
+        if: steps.drift.outputs.drift == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title='Upstream OpenAPI drift: the pinned user-service contract is behind'
+          existing="$(gh issue list --label api-contract --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment 'The committed baseline matches the newest upstream release again.'
+          fi

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -67,8 +67,15 @@ jobs:
           # matters too — `.[0].number` on no matches yields the string "null",
           # which is truthy in the test below.
           title='Upstream OpenAPI drift in the pinned user-service contract'
-          existing="$(gh issue list --label api-contract --state open --limit 100 \
-            --json number,title |
+          # Fail rather than guess: a `gh issue list` that errors (rate limit,
+          # API blip) writes nothing to stdout, which reads as "no tracking issue
+          # exists" and would file a duplicate every night it happens.
+          if ! open_issues="$(gh issue list --label api-contract --state open --limit 100 \
+            --json number,title)"; then
+            echo "::error::could not list open api-contract issues; not filing a possible duplicate"
+            exit 1
+          fi
+          existing="$(printf '%s' "$open_issues" |
             jq -r --arg title "$title" 'map(select(.title == $title)) | .[0].number // empty')"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body-file reports/openapi-drift.md
@@ -83,8 +90,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           title='Upstream OpenAPI drift in the pinned user-service contract'
-          existing="$(gh issue list --label api-contract --state open --limit 100 \
-            --json number,title |
+          # A failed list here is harmless (nothing gets closed), so it only
+          # warns — unlike the filing step, where it would create a duplicate.
+          open_issues="$(gh issue list --label api-contract --state open --limit 100 \
+            --json number,title)" || open_issues='[]'
+          existing="$(printf '%s' "$open_issues" |
             jq -r --arg title "$title" 'map(select(.title == $title)) | .[0].number // empty')"
           if [ -n "$existing" ]; then
             gh issue close "$existing" \

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -96,10 +96,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           title='Upstream OpenAPI drift in the pinned user-service contract'
-          # A failed list here is harmless (nothing gets closed), so it only
-          # warns — unlike the filing step, where it would create a duplicate.
-          open_issues="$(gh issue list --label api-contract --state open --limit 200 \
-            --search "\"$title\" in:title" --json number,title)" || open_issues='[]'
+          # A failed list here is harmless (nothing gets closed), so it warns
+          # instead of failing — unlike the filing step, where the same failure
+          # would create a duplicate. The warning matters: without it a stale
+          # tracking issue would stay open with the run still reporting success.
+          if ! open_issues="$(gh issue list --label api-contract --state open --limit 200 \
+            --search "\"$title\" in:title" --json number,title)"; then
+            echo "::warning::could not list open api-contract issues; no tracking issue was closed"
+            open_issues='[]'
+          fi
           existing="$(printf '%s' "$open_issues" |
             jq -r --arg title "$title" 'map(select(.title == $title)) | .[0].number // empty')"
           if [ -n "$existing" ]; then

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -59,9 +59,17 @@ jobs:
         run: |
           # `api-contract` is an existing repository label; `gh issue create
           # --label <unknown>` errors and would silently drop the report.
-          title='Upstream OpenAPI drift: the pinned user-service contract is behind'
-          existing="$(gh issue list --label api-contract --state open \
-            --search "$title in:title" --json number --jq '.[0].number')"
+          #
+          # Dedup is an EXACT title match, not `--search "<title> in:title"`:
+          # GitHub's search ORs the terms, so a loose search would match any other
+          # open api-contract issue (the tracking issue for this gate itself, for
+          # one) and the nightly would comment on the wrong thread. `// empty`
+          # matters too — `.[0].number` on no matches yields the string "null",
+          # which is truthy in the test below.
+          title='Upstream OpenAPI drift in the pinned user-service contract'
+          existing="$(gh issue list --label api-contract --state open --limit 100 \
+            --json number,title |
+            jq -r --arg title "$title" 'map(select(.title == $title)) | .[0].number // empty')"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body-file reports/openapi-drift.md
           else
@@ -74,9 +82,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          title='Upstream OpenAPI drift: the pinned user-service contract is behind'
-          existing="$(gh issue list --label api-contract --state open \
-            --search "$title in:title" --json number --jq '.[0].number')"
+          title='Upstream OpenAPI drift in the pinned user-service contract'
+          existing="$(gh issue list --label api-contract --state open --limit 100 \
+            --json number,title |
+            jq -r --arg title "$title" 'map(select(.title == $title)) | .[0].number // empty')"
           if [ -n "$existing" ]; then
             gh issue close "$existing" \
               --comment 'The committed baseline matches the newest upstream release again.'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ make test-unit-client   # Client unit tests (TEST_ENV=client, jsdom)
 make test-unit-server   # Apollo server unit tests (TEST_ENV=server, node)
 make test-unit-edge     # Edge-script unit tests (TEST_ENV=edge, node; scripts/, 100% per-file)
 make test-integration   # Integration layer (TEST_ENV=integration)
+make test-contract      # Mockoon mock vs. the committed OpenAPI contract (TEST_ENV=contract)
 make test-e2e           # Playwright E2E (prod stack + Mockoon API mock)
 make test-visual        # Playwright visual regression
 make test-visual-update # Refresh visual snapshots after a reviewed UI change
@@ -100,9 +101,10 @@ make lint-md    # markdownlint
 make lint-deps  # dependency-cruiser on src, pages, tests
 ```
 
-Two gates sit deliberately outside `make lint`: `make lint-metrics` (host-only Rust
-binary) and `make lint-contracts` (needs network for its drift check). Each has its own
-workflow — `rust-code-analysis.yml` and `contract-testing.yml`.
+Three gates sit deliberately outside `make lint`: `make lint-metrics` (host-only Rust
+binary), `make lint-contracts` (needs network for its drift check), and
+`make lint-openapi` (both — a host Go binary plus the network). Each has its own workflow
+— `rust-code-analysis.yml`, `contract-testing.yml` and `openapi-drift.yml`.
 
 Run `make format` before `make lint`; formatting is intentionally separate from the lint
 verification suite. Git hooks are managed by Husky. CI phases are mirrored locally by
@@ -112,6 +114,34 @@ PR review comments.
 
 Never satisfy a gate with `eslint-disable`, `prettier-ignore`, a markdownlint disable, or a
 lowered threshold — fix the root cause.
+
+### API contract parity (issue #350)
+
+Every Playwright e2e run talks to Mockoon, so a green e2e suite alone only proves the app
+agrees with the **mock**. Two gates anchored on the single committed baseline
+`contracts/user-service/openapi.json` — the artifact `lint-contracts` drift-gates and
+`Mockoon.Dockerfile` serves — keep that mock honest. Never add a second copy of the spec.
+
+- **`make test-contract` — blocking, every PR** (`contract-parity-testing.yml`). The
+  `TEST_ENV=contract` Jest layer (`tests/contract/**/*.contract.test.ts`) boots Mockoon
+  in-process via `@mockoon/commons-server`, replays every documented operation, and asserts
+  four rules per response: the status is documented, the media type is declared, the body
+  validates against the schema, and the body carries **no property the schema never
+  declares**. That last rule is stricter than OpenAPI's permissive default on purpose — it
+  is the only one that catches a renamed field here, because upstream misplaces `required`
+  on the array schema of `GET /api/users` rather than on its `items`.
+  `parity-detects-drift.contract.test.ts` seeds real defects into **copies** of the mock
+  data and asserts each turns the gate red; never seed a defect into the committed
+  contract, which `lint-contracts` guards. The `@mockoon/*` devDependencies are pinned
+  **exactly** to the `@mockoon/cli` version `Mockoon.Dockerfile` installs and a spec
+  enforces it — move both pins in the same commit, never relax the assertion.
+- **`make lint-openapi` — advisory, nightly** (`openapi-drift.yml`). A pinned,
+  SHA256-verified `oasdiff` compares the baseline to the newest upstream **release**
+  (resolved from the releases API, not by semver-sorting tags — upstream restarted its
+  numbering). `scripts/ci/openapi-drift.sh` exits three ways on purpose: `0` clean, `1`
+  breaking drift, `2` the check could not run, so an outage is never published as an API
+  change. GNU Make discards a recipe's exit status, so the workflow calls the script
+  directly. Breaking drift files/refreshes an `api-contract` issue instead of failing.
 
 ### Code Metrics (rust-code-analysis, issue #224)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,10 @@ proves the app agrees with the mock:
   the committed document and holds every documented operation's response against
   it — status, media type, schema, and no property the schema never declares.
   Its CI home is
-  [`contract-parity-testing.yml`](.github/workflows/contract-parity-testing.yml).
+  [`contract-parity-testing.yml`](.github/workflows/contract-parity-testing.yml);
+  the status-check name a maintainer must add to the `main` required-checks
+  ruleset is **`contract parity testing / mock-contract-parity`** (branch
+  protection is a repository setting and cannot be committed).
   It also validates the swagger e2e fixtures against the same schema and pins the
   `@mockoon/*` libraries to the `@mockoon/cli` version `Mockoon.Dockerfile`
   installs. When it goes red, fix the mock or the contract — never relax a rule.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,30 @@ update-contracts` — it re-fetches both artifacts and refreshes the spectral
 baseline. Commit the resulting diff; it is the reviewable record of what
 changed upstream.
 
+Two further gates keep the **mock** honest, because the whole Playwright suite
+talks to Mockoon rather than a real backend and a green e2e run therefore only
+proves the app agrees with the mock:
+
+- **`make test-contract` (blocking, every PR).** Boots Mockoon in-process from
+  the committed document and holds every documented operation's response against
+  it — status, media type, schema, and no property the schema never declares.
+  Its CI home is
+  [`contract-parity-testing.yml`](.github/workflows/contract-parity-testing.yml).
+  It also validates the swagger e2e fixtures against the same schema and pins the
+  `@mockoon/*` libraries to the `@mockoon/cli` version `Mockoon.Dockerfile`
+  installs. When it goes red, fix the mock or the contract — never relax a rule.
+  If you bump one Mockoon pin, bump both in the same commit.
+- **`make lint-openapi` (advisory, nightly).** Reports breaking changes between
+  the committed baseline and the newest upstream **release** using a pinned,
+  SHA256-verified `oasdiff`. Upstream moving on is not a PR author's fault, so
+  [`openapi-drift.yml`](.github/workflows/openapi-drift.yml) files or refreshes an
+  `api-contract` tracking issue instead of failing a check, and closes it once
+  the baseline is current again. Like `lint-contracts` and `lint-metrics` it sits
+  outside `make lint` — it needs the network and a host binary.
+
+Both gates read the single committed baseline. Do not add a second copy of the
+spec: it would drift with nothing watching it.
+
 The baseline in [`contracts/spectral-baseline.json`](contracts/spectral-baseline.json)
 records defects in the upstream spec that this repo does not control. It is not
 a suppression list: the gate fails on any finding **not** in it, and equally on

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ NETWORK_NAME                = website-network
 # run the same CI stages as the pipeline. The parallel runners execute each
 # target concurrently, group their output, and aggregate exit codes.
 CI_LINT_TARGETS             = lint-next lint-tsc lint-md
-CI_TEST_TARGETS             = ci-test-unit-client ci-test-unit-server ci-test-integration
+CI_TEST_TARGETS             = ci-test-unit-client ci-test-unit-server ci-test-integration ci-test-contract
 CI_LINT_RUNNER              = ./scripts/ci/run-parallel.sh ci-lint
 CI_TEST_RUNNER              = ./scripts/ci/run-parallel.sh ci-test
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,22 @@ RCA_EXCLUDES                = */test/* *.d.ts */assets/* */config/*
 METRICS_POLICY_PATH         = config/metrics-policy.json
 RCA_SHA256_LINUX            = 9ec2a217b8ff191e02dab5d5f2eee6158b63fd975c532b2c5d67c2e6c7249894
 
+# oasdiff is a host-installed Go binary provisioned exactly like RCA above: pinned
+# version + pinned digest, installed to the gitignored ./bin. Never resolve it as
+# "latest" at install time — that would silently defeat the checksum pin. The
+# digest is the one oasdiff publishes in the release's checksums.txt for
+# oasdiff_$(OASDIFF_VERSION)_linux_amd64.tar.gz (note: the asset name carries no
+# leading "v"; only the tag does).
+OASDIFF_VERSION             = 1.27.0
+OASDIFF_BIN                 = ./bin/oasdiff
+OASDIFF_SHA256_LINUX        = 335de79be8df706735f7ab3edc35186e853c8add93d489d67e4e7fd70a07d08a
+# The upstream repo whose newest release the nightly leg compares the committed
+# baseline against. The pin the repo actually consumes stays USER_SERVICE_VERSION
+# in .env — this is only the moving target the drift report is written about.
+USER_SERVICE_REPO           = VilnaCRM-Org/user-service
+USER_SERVICE_SPEC_PATH      = .github/openapi-spec/spec.yaml
+OPENAPI_BASELINE            = contracts/user-service/openapi.json
+
 NEXT_BUILD                  = $(NEXT_BIN) build --webpack
 NEXT_BUILD_CMD              = $(NEXT_BUILD) && $(IMG_OPTIMIZE)
 STORYBOOK_BUILD_CMD         = $(STORYBOOK_BIN) build --output-dir storybook-static-ci
@@ -332,6 +348,30 @@ lint: lint-next lint-tsc lint-md lint-deps ## Runs all linters: ESLint, TypeScri
 lint-contracts: ## Validate the pinned user-service contracts: client GraphQL operations, the OpenAPI spectral baseline, and artifact drift
 	$(PM_EXEC) node scripts/contracts/lint-contracts.mjs
 
+# DELIBERATE DIVERGENCE FROM THE npm-tool LINT GATES, for both of the reasons
+# lint-contracts and lint-metrics each cite one of:
+#   * Host-only: oasdiff is a Go binary absent from the node:*-alpine dev image,
+#     so this target does NOT use $(PM_EXEC) and runs on the host in both modes.
+#   * Network: it resolves the newest upstream release and downloads that spec.
+#   * Therefore NOT in the `lint` aggregate and NOT in CI_LINT_TARGETS — both
+#     route through the dev container / run-parallel.sh, and static-testing.yml
+#     is hermetic by design. Its CI surface is .github/workflows/openapi-drift.yml.
+# ADVISORY BY DESIGN: upstream moving on is not a PR author's fault, so the
+# nightly turns breaking drift into a tracking issue rather than a red check.
+# The BLOCKING contract gate is `make test-contract`.
+# This target is the HUMAN-FACING surface. GNU make collapses every recipe
+# failure to its own exit 2, so it cannot distinguish "breaking drift" (1) from
+# "the check could not run" (2) — openapi-drift.yml therefore calls the script
+# directly. Both paths run the identical script; only the exit-code fidelity
+# differs. The script provisions the pinned binary itself.
+lint-openapi: ## Report breaking changes between the committed OpenAPI baseline and the newest upstream release (host-only, network; advisory)
+	@OASDIFF_BIN="$(OASDIFF_BIN)" OASDIFF_VERSION="$(OASDIFF_VERSION)" \
+	 OASDIFF_SHA256_LINUX="$(OASDIFF_SHA256_LINUX)" \
+	 OPENAPI_BASELINE="$(OPENAPI_BASELINE)" \
+	 USER_SERVICE_REPO="$(USER_SERVICE_REPO)" \
+	 USER_SERVICE_SPEC_PATH="$(USER_SERVICE_SPEC_PATH)" \
+	 bash scripts/ci/openapi-drift.sh
+
 update-contracts: ## Re-fetch the user-service contracts for the pinned USER_SERVICE_VERSION and refresh the spectral baseline
 	$(PM_EXEC) node scripts/fetchSwaggerSchema.mjs
 	$(PM_EXEC) node scripts/fetchGraphqlSchema.mjs
@@ -429,6 +469,19 @@ test-integration-watch: ## Run integration tests in watch mode (TEST_ENV=integra
 
 ci-test-integration: ## Run integration tests directly assuming deps are installed (CI entrypoint)
 	env TEST_ENV=integration $(JEST_BIN) $(JEST_FLAGS)
+
+# The contract layer (#350) boots the Mockoon mock e2e runs against — in-process,
+# via @mockoon/commons-server, the same libraries Mockoon.Dockerfile's CLI wraps —
+# and holds every response against the committed user-service OpenAPI document.
+# It is hermetic: no network, no Docker, no compose stack, so it runs identically
+# on a bare CI runner and inside the dev container. Kept OUT of the integration
+# layer because that layer's charter is a global 100% coverage sweep over src/**,
+# which a spec about an HTTP mock's wire format contributes nothing to.
+test-contract: ## Run the mock-vs-OpenAPI contract parity layer using Jest (TEST_ENV=contract, target: tests/contract)
+	$(UNIT_TESTS) TEST_ENV=contract $(JEST_BIN) $(JEST_FLAGS)
+
+ci-test-contract: ## Run contract parity tests directly assuming deps are installed (CI entrypoint)
+	env TEST_ENV=contract $(JEST_BIN) $(JEST_FLAGS)
 
 # ============================================================================
 # CI orchestration (issue #305 — CRM command-surface parity)

--- a/README.md
+++ b/README.md
@@ -362,12 +362,31 @@ turns the gate red. The gate is hermetic (no Docker, no network) and runs on
 every pull request via
 [`.github/workflows/contract-parity-testing.yml`](.github/workflows/contract-parity-testing.yml).
 
-**Scope, honestly stated:** Mockoon derives its responses from the same document
+**Scope, honestly stated.** Mockoon derives its responses from the same document
 the validator checks against, so this cannot detect "the mock disagrees with the
-real API" in general. What it does catch is every divergence the converter can
-introduce — a schema the generated mock can no longer satisfy after a version
-bump, a Mockoon upgrade that changes generation, a status or media type the mock
-stops serving, and e2e fixtures written against a shape the contract has dropped.
+real API" in general. What it does catch is divergence the converter introduces:
+a schema the generated mock can no longer satisfy after a version bump, a Mockoon
+upgrade that changes generation, a status or media type the mock stops serving,
+and e2e fixtures written against a shape the contract has dropped.
+
+Its reach is bounded in three ways, all deliberate and all guarded:
+
+- **One response per operation.** Mockoon serves the first response an operation
+  declares and honours neither `Accept` nor `Prefer`, so the documented 4xx/5xx
+  shapes are never exercised. 12 responses are observed out of 43 declared
+  (status, media-type) pairs.
+- **Body only, not headers.** Response headers — including the `Location` on the
+  302 — are served but not asserted.
+- **Schema-bearing responses only.** 7 of the 12 reach the schema and
+  undeclared-property rules; the rest declare `example: ""` with no schema, or
+  are bodyless 204s. A committed floor assertion fails if that 7 ever drops, so
+  the gate cannot quietly shrink toward validating nothing.
+
+Composed schemas (`allOf`, `oneOf`, `prefixItems`, …) and `$ref` are likewise a
+tripwire rather than a silent gap: the undeclared-property rule walks
+`properties`/`items` only, so the spec fails loudly if upstream introduces one
+instead of quietly checking less.
+
 The "is the contract itself current?" question is the second gate's job.
 
 ### Advisory: upstream drift
@@ -380,8 +399,9 @@ Downloads a pinned, SHA256-verified `oasdiff` binary (the same provisioning
 pattern as the rust-code-analysis CLI) and reports breaking changes between the
 committed baseline and the newest `VilnaCRM-Org/user-service` **release**. Latest
 is resolved from the releases API rather than by semver-sorting tags, because
-upstream restarted its numbering — the newest tag by semver is a year older than
-the newest release.
+upstream restarted its numbering: the highest tag by semver is `v2.8.0`
+(Aug 2025), while the newest release is `v0.8.0` (Feb 2026). Semver-sorting
+would compare against months-old content and report "no drift" indefinitely.
 
 This leg is **advisory by design**: upstream moving on is not a pull request
 author's fault, so it never blocks a PR. It runs nightly via

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Linting & Formatting
   make lint: runs all linters (ESLint, TypeScript, markdownlint, and dependency-cruiser)
   make lint-metrics: runs the rust-code-analysis complexity gate (host-only, not in make lint)
   make lint-contracts: validates the pinned user-service contracts (not in make lint; needs network)
+  make lint-openapi: reports breaking upstream OpenAPI drift (host-only, needs network; advisory)
   make update-contracts: re-fetches the contracts after bumping USER_SERVICE_VERSION
 ```
 
@@ -113,6 +114,7 @@ Testing
   make test-unit-server: runs unit tests for the server using Jest
   make test-integration: runs the integration layer (real Apollo transport, network stubbed)
   make test-integration-watch: runs the integration layer in watch mode
+  make test-contract: checks the Mockoon mock against the committed OpenAPI contract
   make test-bats: runs the Bats shell regression suite for Makefile targets and CI helper scripts
   make test-memory-leak: runs memory leak tests using Memlab
   make load-tests: executes load tests using the K6 library
@@ -166,6 +168,10 @@ the future—you'll need to update the API configuration accordingly.
 To run tests locally, the Mockoon mock server is automatically started via
 `make test-e2e`. For manual setup, see the Mockoon configuration in
 `docker-compose.test.yml`.
+
+Because the entire Playwright suite talks to Mockoon rather than a real backend,
+the mock is itself gated — see
+[API contract parity](#api-contract-parity-mockoon-vs-openapi) below.
 
 Lighthouse
 
@@ -311,6 +317,88 @@ adjust the relevant rule in `.dependency-cruiser.js` — narrow its `from`/`to`
 globs, add a `pathNot` entry, or (only for unavoidable cases) lower its
 `severity` to `warn` — and leave a comment explaining why so the boundary intent
 stays clear.
+
+## API Contract Parity (Mockoon vs OpenAPI)
+
+Every Playwright e2e run talks to Mockoon, never to a real backend, so a green
+e2e suite on its own only proves the app agrees with the **mock**. Two gates keep
+that mock honest, both anchored on the single committed baseline
+[`contracts/user-service/openapi.json`](contracts/user-service/openapi.json) —
+the same artifact `make lint-contracts` drift-gates against `USER_SERVICE_VERSION`
+and the same one `Mockoon.Dockerfile` serves. There is deliberately no second
+baseline file: a copy would be a drift source with nothing watching it.
+
+### Blocking: mock-vs-contract parity
+
+```bash
+make test-contract
+```
+
+Boots Mockoon in-process from the committed document — through
+`@mockoon/commons-server`, the libraries the container's `@mockoon/cli` wraps —
+replays every documented operation, and holds each response against the contract:
+
+- the status served must be one the operation documents;
+- a body must arrive under a media type that status declares;
+- a body must validate against that media type's schema; and
+- a body must not carry a property the schema never declares.
+
+The last rule is stricter than OpenAPI's permissive default on purpose. A mock
+offering a field the contract does not describe is precisely the "e2e certifies
+behavior the real API does not have" defect, and it is the only rule that catches
+a renamed field here, because the upstream document misplaces `required` on the
+array schema of `GET /api/users` instead of on its `items`.
+
+Two further checks ride along: the swagger e2e fixtures in
+`src/test/e2e/swagger/utils/constants.ts` are validated against the same schema,
+and the `@mockoon/*` versions in `package.json` are pinned to the `@mockoon/cli`
+version `Mockoon.Dockerfile` installs, so the gate can never certify a Mockoon
+the e2e stack does not run.
+
+`tests/contract/parity-detects-drift.contract.test.ts` proves the gate bites: it
+writes corrupted **copies** of the mock data — a renamed field, a retyped field,
+an added field, a moved status — boots Mockoon on each, and asserts every one
+turns the gate red. The gate is hermetic (no Docker, no network) and runs on
+every pull request via
+[`.github/workflows/contract-parity-testing.yml`](.github/workflows/contract-parity-testing.yml).
+
+**Scope, honestly stated:** Mockoon derives its responses from the same document
+the validator checks against, so this cannot detect "the mock disagrees with the
+real API" in general. What it does catch is every divergence the converter can
+introduce — a schema the generated mock can no longer satisfy after a version
+bump, a Mockoon upgrade that changes generation, a status or media type the mock
+stops serving, and e2e fixtures written against a shape the contract has dropped.
+The "is the contract itself current?" question is the second gate's job.
+
+### Advisory: upstream drift
+
+```bash
+make lint-openapi
+```
+
+Downloads a pinned, SHA256-verified `oasdiff` binary (the same provisioning
+pattern as the rust-code-analysis CLI) and reports breaking changes between the
+committed baseline and the newest `VilnaCRM-Org/user-service` **release**. Latest
+is resolved from the releases API rather than by semver-sorting tags, because
+upstream restarted its numbering — the newest tag by semver is a year older than
+the newest release.
+
+This leg is **advisory by design**: upstream moving on is not a pull request
+author's fault, so it never blocks a PR. It runs nightly via
+[`.github/workflows/openapi-drift.yml`](.github/workflows/openapi-drift.yml),
+which files or refreshes an `api-contract` tracking issue on breaking drift and
+closes it once the baseline is current again. Adopt a new contract by bumping
+`USER_SERVICE_VERSION` in `.env` and running `make update-contracts`.
+
+[`scripts/ci/openapi-drift.sh`](scripts/ci/openapi-drift.sh) exits three ways on
+purpose — `0` clean, `1` breaking drift, `2` the check could not run — so a
+network outage is never published as an API change. GNU Make discards a recipe's
+own exit status, so the workflow calls the script directly while
+`make lint-openapi` stays the human-facing surface.
+
+Like `make lint-contracts` and `make lint-metrics`, `make lint-openapi` is
+deliberately **outside** `make lint`: it needs the network and a host binary, and
+the static lint lane is hermetic by design.
 
 ## Code Metrics (rust-code-analysis)
 

--- a/agents.md
+++ b/agents.md
@@ -29,6 +29,8 @@ than one. Match the change to the suite and run its verification command.
 | Client unit       | Components, hooks, and pure client logic   | `make test-unit-client` |
 | Server unit       | Apollo resolvers and server-side logic     | `make test-unit-server` |
 | Edge unit         | Deployed edge/runtime scripts (`scripts/`) | `make test-unit-edge`   |
+| Integration       | Cross-module / API-boundary wiring         | `make test-integration` |
+| Contract          | The Mockoon mock vs. the OpenAPI contract  | `make test-contract`    |
 | End-to-end (e2e)  | User-facing flows end to end (Mockoon API) | `make test-e2e`         |
 | Visual regression | Any change to rendered UI or styling       | `make test-visual`      |
 
@@ -39,7 +41,12 @@ Client unit tests run on Jest with React Testing Library in a jsdom env
 run on Jest in a node env (`TEST_ENV=edge`) and cover the deployed edge/runtime scripts
 under `scripts/` that ship outside the Next.js bundle (today the CloudFront Functions
 handler `scripts/cloudfront_routing.js`); specs live in `src/test/edge/**/*.test.ts` and
-the layer is pinned at 100% per-file coverage. E2E and visual specs are Playwright across
+the layer is pinned at 100% per-file coverage. Integration specs run in a jsdom-with-fetch
+env (`TEST_ENV=integration`) from `tests/integration/**/*.integration.test.{ts,tsx}` and
+enforce a global 100% coverage sweep over `src/`. Contract specs run in a node env
+(`TEST_ENV=contract`) from `tests/contract/**/*.contract.test.ts`; they boot the Mockoon
+mock the e2e suite runs against and hold every response against the committed
+`contracts/user-service/openapi.json` (issue #350). E2E and visual specs are Playwright across
 chromium, firefox, and webkit (`src/test/e2e/**/*.spec.ts`, `src/test/visual/**/*.spec.ts`);
 visual snapshots sit in adjacent `*-snapshots/` folders. Run all three unit layers with
 `make test-unit-all`.
@@ -115,6 +122,7 @@ pass. Run the layer commands you touched, then the project lint gate.
 make format                  # Prettier formatting (run before lint)
 CI=1 make test-unit-client   # Client unit suite (jsdom)
 CI=1 make test-unit-server   # Server unit suite (node)
+make test-contract           # Mockoon mock vs. the committed OpenAPI contract
 make test-e2e                # User-facing flows (for UI or behavior changes)
 make test-visual             # Visual regression (for UI or styling changes)
 make lint                    # Full gate: ESLint, TypeScript, and markdownlint

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,8 @@
         "@memlab/api": "^2.0.3",
         "@memlab/heap-analysis": "^2.0.3",
         "@microsoft/api-extractor": "^7.58.7",
+        "@mockoon/commons": "9.2.0",
+        "@mockoon/commons-server": "9.2.0",
         "@next/bundle-analyzer": "^16.2.6",
         "@next/env": "^16.2.6",
         "@next/eslint-plugin-next": "^16.2.6",
@@ -108,6 +110,14 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
+    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.7.2", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA=="],
+
+    "@apidevtools/openapi-schemas": ["@apidevtools/openapi-schemas@2.1.0", "", {}, "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="],
+
+    "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
+
+    "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@10.1.1", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "11.7.2", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "@jsdevtools/ono": "^7.1.3", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA=="],
 
     "@apollo/cache-control-types": ["@apollo/cache-control-types@1.0.3", "", { "peerDependencies": { "graphql": "16.14.0" } }, "sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g=="],
 
@@ -569,13 +579,13 @@
 
     "@hapi/formula": ["@hapi/formula@3.0.2", "", {}, "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw=="],
 
-    "@hapi/hoek": ["@hapi/hoek@11.0.7", "", {}, "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ=="],
+    "@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
 
     "@hapi/pinpoint": ["@hapi/pinpoint@2.0.1", "", {}, "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q=="],
 
     "@hapi/tlds": ["@hapi/tlds@1.1.6", "", {}, "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw=="],
 
-    "@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "11.0.7" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
+    "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -725,6 +735,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
+
     "@jsep-plugin/assignment": ["@jsep-plugin/assignment@1.3.0", "", { "peerDependencies": { "jsep": "1.4.0" } }, "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ=="],
 
     "@jsep-plugin/regex": ["@jsep-plugin/regex@1.0.4", "", { "peerDependencies": { "jsep": "1.4.0" } }, "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="],
@@ -754,6 +766,10 @@
     "@microsoft/tsdoc": ["@microsoft/tsdoc@0.16.0", "", {}, "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA=="],
 
     "@microsoft/tsdoc-config": ["@microsoft/tsdoc-config@0.18.1", "", { "dependencies": { "@microsoft/tsdoc": "0.16.0", "ajv": "8.18.0", "jju": "1.4.0", "resolve": "1.22.12" } }, "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg=="],
+
+    "@mockoon/commons": ["@mockoon/commons@9.2.0", "", { "dependencies": { "joi": "17.13.3", "tslib": "2.8.1" } }, "sha512-LvKyewKhvZzXkdFOWj4G3IQxL27kyNelY+EH9cZCMmx0obdUOBwZeGeEKT6hfLmPl59eP1Ax2rh4Db2It+ku+A=="],
+
+    "@mockoon/commons-server": ["@mockoon/commons-server@9.2.0", "", { "dependencies": { "@apidevtools/swagger-parser": "10.1.1", "@faker-js/faker": "9.6.0", "@mockoon/commons": "9.2.0", "ajv": "8.17.1", "ajv-formats": "3.0.1", "append-field": "1.0.0", "busboy": "1.6.0", "cookie-parser": "1.4.7", "date-fns": "4.1.0", "express": "4.21.2", "handlebars": "4.7.8", "http-proxy-middleware": "3.0.3", "jsonpath-plus": "10.3.0", "killable": "1.0.1", "mime-types": "2.1.35", "object-path": "0.11.8", "path-to-regexp": "8.2.0", "qs": "6.14.0", "range-parser": "1.2.1", "tslib": "2.8.1", "typed-emitter": "2.1.0", "winston": "3.17.0", "ws": "8.18.1", "xml-js": "1.6.11" } }, "sha512-6pcj9b9dy/2CNzueBwSOF5EgojtShi5YK8IamiUh+7z7HuYQITpz0eJ11QxG/9g64pQILB85C2FDOxfzHv4PLA=="],
 
     "@mui/core-downloads-tracker": ["@mui/core-downloads-tracker@9.0.1", "", {}, "sha512-GzamIIhZ1bH77dq7eKaeyRgJdkypsxin4jBFq2EMs4lBWRR0LFO1CSVMsoebn/VvjcNrnrOrjy48MkrkQUK2iw=="],
 
@@ -1009,6 +1025,12 @@
 
     "@sentry/utils": ["@sentry/utils@7.120.4", "", { "dependencies": { "@sentry/types": "7.120.4" } }, "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw=="],
 
+    "@sideway/address": ["@sideway/address@4.1.5", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q=="],
+
+    "@sideway/formula": ["@sideway/formula@3.0.1", "", {}, "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="],
+
+    "@sideway/pinpoint": ["@sideway/pinpoint@2.0.0", "", {}, "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="],
+
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
 
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
@@ -1224,6 +1246,8 @@
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "3.0.3" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/html-minifier-terser": ["@types/html-minifier-terser@6.1.0", "", {}, "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg=="],
+
+    "@types/http-proxy": ["@types/http-proxy@1.17.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
 
@@ -1471,6 +1495,8 @@
 
     "app-root-path": ["app-root-path@3.1.0", "", {}, "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA=="],
 
+    "append-field": ["append-field@1.0.0", "", {}, "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="],
+
     "arch": ["arch@2.2.0", "", {}, "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
@@ -1629,6 +1655,8 @@
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "7.1.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
+    "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "1.0.2", "es-define-property": "1.0.1", "get-intrinsic": "1.3.0", "set-function-length": "1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
@@ -1636,6 +1664,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "1.3.0", "function-bind": "1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "1.0.2", "get-intrinsic": "1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -1755,6 +1785,8 @@
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
+    "cookie-parser": ["cookie-parser@1.4.7", "", { "dependencies": { "cookie": "0.7.2", "cookie-signature": "1.0.6" } }, "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw=="],
+
     "cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
 
     "copy-to-clipboard": ["copy-to-clipboard@3.3.3", "", { "dependencies": { "toggle-selection": "1.0.6" } }, "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA=="],
@@ -1814,6 +1846,8 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "1.0.4", "es-errors": "1.3.0", "is-data-view": "1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "1.0.4", "es-errors": "1.3.0", "is-data-view": "1.0.2" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "debounce": ["debounce@1.2.1", "", {}, "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="],
 
@@ -2035,6 +2069,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "2.8.3" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
@@ -2193,7 +2229,7 @@
 
     "gzip-size": ["gzip-size@6.0.0", "", { "dependencies": { "duplexer": "0.1.2" } }, "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q=="],
 
-    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "1.2.8", "neo-async": "2.6.2", "source-map": "0.6.1", "wordwrap": "1.0.0" }, "optionalDependencies": { "uglify-js": "3.19.3" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+    "handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -2251,7 +2287,11 @@
 
     "http-link-header": ["http-link-header@1.1.3", "", {}, "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ=="],
 
+    "http-proxy": ["http-proxy@1.18.1", "", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
+
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "7.1.4", "debug": "4.4.3" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "http-proxy-middleware": ["http-proxy-middleware@3.0.3", "", { "dependencies": { "@types/http-proxy": "^1.17.15", "debug": "^4.3.6", "http-proxy": "^1.18.1", "is-glob": "^4.0.3", "is-plain-object": "^5.0.0", "micromatch": "^4.0.8" } }, "sha512-usY0HG5nyDUwtqpiZdETNbmKtw3QQ1jwYFZ9wi5iHzX2BcILwQKtYDJPo7XHTsu5Z0B2Hj3W9NNnbd+AjFWjqg=="],
 
     "https-browserify": ["https-browserify@1.0.0", "", {}, "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="],
 
@@ -2489,7 +2529,7 @@
 
     "jju": ["jju@1.4.0", "", {}, "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="],
 
-    "joi": ["joi@18.2.1", "", { "dependencies": { "@hapi/address": "5.1.1", "@hapi/formula": "3.0.2", "@hapi/hoek": "11.0.7", "@hapi/pinpoint": "2.0.1", "@hapi/tlds": "1.1.6", "@hapi/topo": "6.0.2", "@standard-schema/spec": "1.1.0" } }, "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ=="],
+    "joi": ["joi@17.13.3", "", { "dependencies": { "@hapi/hoek": "^9.3.0", "@hapi/topo": "^5.1.0", "@sideway/address": "^4.1.5", "@sideway/formula": "^3.0.1", "@sideway/pinpoint": "^2.0.0" } }, "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA=="],
 
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
@@ -2525,7 +2565,7 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "4.2.11" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
-    "jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "1.3.0", "@jsep-plugin/regex": "1.0.4", "jsep": "1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
+    "jsonpath-plus": ["jsonpath-plus@10.3.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA=="],
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
@@ -2534,6 +2574,8 @@
     "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "killable": ["killable@1.0.1", "", {}, "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg=="],
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
@@ -2707,9 +2749,9 @@
 
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "mime-types": ["mime-types@2.1.18", "", { "dependencies": { "mime-db": "1.33.0" } }, "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -2805,6 +2847,8 @@
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
+    "object-path": ["object-path@0.11.8", "", {}, "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA=="],
+
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "1.0.9", "call-bound": "1.0.4", "define-properties": "1.2.1", "es-object-atoms": "1.1.2", "has-symbols": "1.1.0", "object-keys": "1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
 
     "object.entries": ["object.entries@1.1.9", "", { "dependencies": { "call-bind": "1.0.9", "call-bound": "1.0.4", "define-properties": "1.2.1", "es-object-atoms": "1.1.2" } }, "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw=="],
@@ -2834,6 +2878,8 @@
     "openapi-path-templating": ["openapi-path-templating@2.2.1", "", { "dependencies": { "apg-lite": "1.0.5" } }, "sha512-eN14VrDvl/YyGxxrkGOHkVkWEoPyhyeydOUrbvjoz8K5eIGgELASwN1eqFOJ2CTQMGCy2EntOK1KdtJ8ZMekcg=="],
 
     "openapi-server-url-templating": ["openapi-server-url-templating@1.3.0", "", { "dependencies": { "apg-lite": "1.0.5" } }, "sha512-DPlCms3KKEbjVQb0spV6Awfn6UWNheuG/+folQPzh/wUaKwuqvj8zt5gagD7qoyxtE03cIiKPgLFS3Q8Bz00uQ=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "opener": ["opener@1.5.2", "", { "bin": { "opener": "bin/opener-bin.js" } }, "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A=="],
 
@@ -2899,7 +2945,7 @@
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "10.4.3", "minipass": "7.1.3" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "path-to-regexp": ["path-to-regexp@0.1.13", "", {}, "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="],
+    "path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -2987,7 +3033,7 @@
 
     "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
-    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+    "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 
     "querystring-es3": ["querystring-es3@0.2.1", "", {}, "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="],
 
@@ -3167,6 +3213,8 @@
 
     "sass-loader": ["sass-loader@16.0.8", "", { "dependencies": { "neo-async": "2.6.2" }, "optionalDependencies": { "sass": "1.100.0", "webpack": "5.107.2" } }, "sha512-hcov4ZwZJIGbEuyNr9EmiTmZueyrxSToE6GOzoZnq5JM7ecRO7ttyvilPn+VmRsqiP16+VYZzVnGZj/hzZgKBA=="],
 
+    "sax": ["sax@1.6.1", "", {}, "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q=="],
+
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
@@ -3266,6 +3314,8 @@
     "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "2.0.4", "readable-stream": "3.6.2" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
 
     "stream-http": ["stream-http@3.2.0", "", { "dependencies": { "builtin-status-codes": "3.0.0", "inherits": "2.0.4", "readable-stream": "3.6.2", "xtend": "4.0.2" } }, "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A=="],
+
+    "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
 
     "streamx": ["streamx@2.26.0", "", { "dependencies": { "events-universal": "1.0.1", "fast-fifo": "1.3.2", "text-decoder": "1.2.7" } }, "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A=="],
 
@@ -3433,6 +3483,8 @@
 
     "typed-array-length": ["typed-array-length@1.0.8", "", { "dependencies": { "call-bind": "1.0.9", "for-each": "0.3.5", "gopd": "1.2.0", "is-typed-array": "1.1.15", "possible-typed-array-names": "1.1.0", "reflect.getprototypeof": "1.0.10" } }, "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g=="],
 
+    "typed-emitter": ["typed-emitter@2.1.0", "", { "optionalDependencies": { "rxjs": "*" } }, "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA=="],
+
     "typed-inject": ["typed-inject@5.0.0", "", {}, "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA=="],
 
     "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
@@ -3585,7 +3637,7 @@
 
     "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "0.1.4", "signal-exit": "4.1.0" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
-    "ws": ["ws@8.21.0", "", {}, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "3.1.1" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
@@ -3594,6 +3646,8 @@
     "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
 
     "xml-but-prettier": ["xml-but-prettier@1.0.1", "", { "dependencies": { "repeat-string": "1.6.1" } }, "sha512-C2CJaadHrZTqESlH03WOyw0oZTtoy2uEg6dSDF6YRg+9GnYNub53RRemLpnvtbHDFelxMx4LajiFsYeR6XJHgQ=="],
+
+    "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -3659,6 +3713,8 @@
 
     "@eslint/eslintrc/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-json-stable-stringify": "2.1.0", "json-schema-traverse": "0.4.1", "uri-js": "4.4.1" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
+    "@hapi/address/@hapi/hoek": ["@hapi/hoek@11.0.7", "", {}, "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ=="],
+
     "@inquirer/core/cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "@inquirer/core/mute-stream": ["mute-stream@4.0.0", "", {}, "sha512-gSrprq0fJ3EiOErzjdIZrjysVVmJ4uu1QWfCDss5LypA5OXvrMje5Ym5z6V6RLyJ2eF87lasX7t6a0AnFvZblg=="],
@@ -3711,6 +3767,14 @@
 
     "@microsoft/tsdoc-config/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-uri": "3.1.2", "json-schema-traverse": "1.0.0", "require-from-string": "2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "@mockoon/commons-server/@faker-js/faker": ["@faker-js/faker@9.6.0", "", {}, "sha512-3vm4by+B5lvsFPSyep3ELWmZfE3kicDtmemVpuwl1yH7tqtnHdsA6hG8fbXedMVdkzgtvzWoRgjSB4Q+FHnZiw=="],
+
+    "@mockoon/commons-server/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "@mockoon/commons-server/express": ["express@4.21.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "1.20.3", "content-disposition": "0.5.4", "content-type": "~1.0.4", "cookie": "0.7.1", "cookie-signature": "1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "1.3.1", "fresh": "0.5.2", "http-errors": "2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "0.1.12", "proxy-addr": "~2.0.7", "qs": "6.13.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "0.19.0", "serve-static": "1.16.2", "setprototypeof": "1.2.0", "statuses": "2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA=="],
+
+    "@mockoon/commons-server/winston": ["winston@3.17.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.2", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw=="],
+
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "2.8.1" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
@@ -3756,6 +3820,8 @@
     "@stoplight/spectral-core/@stoplight/types": ["@stoplight/types@13.6.0", "", { "dependencies": { "@types/json-schema": "7.0.15", "utility-types": "3.11.0" } }, "sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ=="],
 
     "@stoplight/spectral-core/ajv-formats": ["ajv-formats@2.1.1", "", { "optionalDependencies": { "ajv": "8.20.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
+
+    "@stoplight/spectral-core/jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "1.3.0", "@jsep-plugin/regex": "1.0.4", "jsep": "1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
 
     "@stoplight/spectral-formatters/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "4.2.3", "strip-ansi": "6.0.1", "wrap-ansi": "7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
@@ -3827,8 +3893,6 @@
 
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "2.8.1" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
-    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "adjust-sourcemap-loader/loader-utils": ["loader-utils@2.0.4", "", { "dependencies": { "big.js": "5.2.2", "emojis-list": "3.0.0", "json5": "2.2.3" } }, "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw=="],
@@ -3848,6 +3912,8 @@
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "4.0.2", "import-fresh": "3.3.1", "parse-json": "5.2.0", "path-type": "4.0.0", "yaml": "1.10.3" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "body-parser/qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
     "body-parser/type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "2.0.0", "media-typer": "1.1.0", "mime-types": "3.0.2" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
@@ -3877,11 +3943,15 @@
 
     "color-string/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
+    "compressible/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "compression/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "configstore/write-file-atomic": ["write-file-atomic@3.0.3", "", { "dependencies": { "imurmurhash": "0.1.4", "is-typedarray": "1.0.0", "signal-exit": "3.0.7", "typedarray-to-buffer": "3.1.5" } }, "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="],
+
+    "cookie-parser/cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
 
     "cosmiconfig-typescript-loader/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -3937,6 +4007,10 @@
 
     "express/finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "2.0.0", "escape-html": "1.0.3", "on-finished": "2.4.1", "parseurl": "1.3.3", "statuses": "2.0.2", "unpipe": "1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
 
+    "express/path-to-regexp": ["path-to-regexp@0.1.13", "", {}, "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="],
+
+    "express/qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": "2.1.2" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "external-editor/tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
@@ -3956,8 +4030,6 @@
     "fork-ts-checker-webpack-plugin/fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "4.2.11", "jsonfile": "6.2.1", "universalify": "2.0.1" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "fork-ts-checker-webpack-plugin/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "7.0.15", "ajv": "6.15.0", "ajv-keywords": "3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
-
-    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -4029,6 +4101,8 @@
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
+    "jsdom/ws": ["ws@8.21.0", "", {}, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "lighthouse/@sentry/node": ["@sentry/node@7.120.4", "", { "dependencies": { "@sentry-internal/tracing": "7.120.4", "@sentry/core": "7.120.4", "@sentry/integrations": "7.120.4", "@sentry/types": "7.120.4", "@sentry/utils": "7.120.4" } }, "sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw=="],
@@ -4063,13 +4137,13 @@
 
     "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
-    "mime-types/mime-db": ["mime-db@1.33.0", "", {}, "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="],
-
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "3.3.12", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "next/styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "optionalDependencies": { "@babel/core": "7.29.7", "babel-plugin-macros": "3.1.0" }, "peerDependencies": { "react": "19.2.6" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "next-export-optimize-images/fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "4.2.11", "jsonfile": "6.2.1", "universalify": "2.0.1" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
+
+    "nimma/jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "1.3.0", "@jsep-plugin/regex": "1.0.4", "jsep": "1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
 
     "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -4098,6 +4172,8 @@
     "puppeteer/devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
 
     "puppeteer-core/devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
+
+    "puppeteer-core/ws": ["ws@8.21.0", "", {}, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
@@ -4147,6 +4223,8 @@
 
     "serve-handler/content-disposition": ["content-disposition@0.5.2", "", {}, "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="],
 
+    "serve-handler/mime-types": ["mime-types@2.1.18", "", { "dependencies": { "mime-db": "1.33.0" } }, "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ=="],
+
     "serve-handler/path-to-regexp": ["path-to-regexp@3.3.0", "", {}, "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="],
 
     "serve-handler/range-parser": ["range-parser@1.2.0", "", {}, "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A=="],
@@ -4156,6 +4234,8 @@
     "storybook/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "storybook/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "5.5.0", "define-lazy-prop": "3.0.0", "is-inside-container": "1.0.0", "wsl-utils": "0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "storybook/ws": ["ws@8.21.0", "", {}, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "string-length/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -4181,6 +4261,8 @@
 
     "ts-jest/@jest/transform": ["@jest/transform@30.4.1", "", { "dependencies": { "@babel/core": "7.29.7", "@jest/types": "30.4.1", "@jridgewell/trace-mapping": "0.3.31", "babel-plugin-istanbul": "7.0.1", "chalk": "4.1.2", "convert-source-map": "2.0.0", "fast-json-stable-stringify": "2.1.0", "graceful-fs": "4.2.11", "jest-haste-map": "30.4.1", "jest-regex-util": "30.4.0", "jest-util": "30.4.1", "pirates": "4.0.7", "slash": "3.0.0", "write-file-atomic": "5.0.1" } }, "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ=="],
 
+    "ts-jest/handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "1.2.8", "neo-async": "2.6.2", "source-map": "0.6.1", "wordwrap": "1.0.0" }, "optionalDependencies": { "uglify-js": "3.19.3" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
     "ts-jest/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "ts-node/arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
@@ -4193,19 +4275,21 @@
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "typed-rest-client/qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "url/punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
+    "url/qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "wait-on/joi": ["joi@18.2.1", "", { "dependencies": { "@hapi/address": "5.1.1", "@hapi/formula": "3.0.2", "@hapi/hoek": "11.0.7", "@hapi/pinpoint": "2.0.1", "@hapi/tlds": "1.1.6", "@hapi/topo": "6.0.2", "@standard-schema/spec": "1.1.0" } }, "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ=="],
+
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "4.3.0", "estraverse": "4.3.0" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
+
+    "webpack/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "webpack-bundle-analyzer/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "webpack-bundle-analyzer/ws": ["ws@7.5.11", "", {}, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
-
-    "webpack-dev-middleware/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "webpack-hot-middleware/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -4273,6 +4357,28 @@
 
     "@microsoft/api-extractor/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "4.0.4" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
+    "@mockoon/commons-server/express/body-parser": ["body-parser@1.20.3", "", { "dependencies": { "bytes": "3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "on-finished": "2.4.1", "qs": "6.13.0", "raw-body": "2.5.2", "type-is": "~1.6.18", "unpipe": "1.0.0" } }, "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g=="],
+
+    "@mockoon/commons-server/express/cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
+
+    "@mockoon/commons-server/express/cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
+
+    "@mockoon/commons-server/express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "@mockoon/commons-server/express/finalhandler": ["finalhandler@1.3.1", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "2.4.1", "parseurl": "~1.3.3", "statuses": "2.0.1", "unpipe": "~1.0.0" } }, "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ=="],
+
+    "@mockoon/commons-server/express/http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
+
+    "@mockoon/commons-server/express/path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
+
+    "@mockoon/commons-server/express/qs": ["qs@6.13.0", "", { "dependencies": { "side-channel": "^1.0.6" } }, "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg=="],
+
+    "@mockoon/commons-server/express/send": ["send@0.19.0", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "0.5.2", "http-errors": "2.0.0", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "2.4.1", "range-parser": "~1.2.1", "statuses": "2.0.1" } }, "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw=="],
+
+    "@mockoon/commons-server/express/serve-static": ["serve-static@1.16.2", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "0.19.0" } }, "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw=="],
+
+    "@mockoon/commons-server/express/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
+
     "@rushstack/node-core-library/fs-extra/jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "2.0.1" }, "optionalDependencies": { "graceful-fs": "4.2.11" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
     "@rushstack/node-core-library/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
@@ -4302,8 +4408,6 @@
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "4.0.4" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
-
-    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4.4.3" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
@@ -4364,8 +4468,6 @@
     "fork-ts-checker-webpack-plugin/schema-utils/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-json-stable-stringify": "2.1.0", "json-schema-traverse": "0.4.1", "uri-js": "4.4.1" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "fork-ts-checker-webpack-plugin/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "6.15.0" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
-
-    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "inquirer/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "1.9.3" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
@@ -4459,6 +4561,8 @@
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "serve-handler/mime-types/mime-db": ["mime-db@1.33.0", "", {}, "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="],
+
     "storybook/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
     "storybook/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
@@ -4521,9 +4625,9 @@
 
     "ts-jest/@jest/transform/jest-regex-util": ["jest-regex-util@30.4.0", "", {}, "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg=="],
 
-    "type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "wait-on/joi/@hapi/hoek": ["@hapi/hoek@11.0.7", "", {}, "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ=="],
 
-    "webpack-dev-middleware/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "wait-on/joi/@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "11.0.7" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
 
     "webpack-hot-middleware/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -4557,11 +4661,21 @@
 
     "@microsoft/api-extractor/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "@mockoon/commons-server/express/body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": "2.1.2" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "@mockoon/commons-server/express/body-parser/raw-body": ["raw-body@2.5.2", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "unpipe": "1.0.0" } }, "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="],
+
+    "@mockoon/commons-server/express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "@mockoon/commons-server/express/send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
     "@stryker-mutator/core/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@swagger-api/apidom-reference/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "body-parser/type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,7 +74,8 @@ export default [
       'docker/**/*.{js,ts,mts}',
       '**/*.stories.@(js|jsx|ts|tsx)',
       'src/test/**/*',
-      'tests/integration/**/*.{ts,tsx}',
+      // Every layer under tests/ — integration (#328) and contract (#350).
+      'tests/**/*.{ts,tsx}',
     ],
     languageOptions: {
       parser: '@typescript-eslint/parser',
@@ -271,11 +272,11 @@ export default [
   },
 
   {
-    // Integration tests resolve via tsconfig paths + .ts/.tsx extensions and use
+    // Specs under tests/ resolve via tsconfig paths + .ts/.tsx extensions and use
     // test-only fetch/observer stubs. The FlatCompat-nested overrides above set
     // these rules, but sandboxed eslint runs (qlty/CI) only apply top-level flat
     // config, so re-declare them here as the last matching block for these files.
-    files: ['tests/integration/**/*.{js,ts,tsx}'],
+    files: ['tests/**/*.{js,ts,tsx}'],
     rules: {
       'import/no-unresolved': 'off',
       'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,8 @@ const createJestConfig = nextJest({ dir: './' });
  * - `server`               — Apollo server tests (Node) + pure unit tests.
  * - `integration`          — the cross-module / API-boundary layer that lives
  *                            in `tests/integration/**`.
+ * - `contract`             — the mock-vs-contract parity layer in
+ *                            `tests/contract/**` (#350).
  *
  * The integration layer is intentionally isolated from the unit globs: it is
  * the "missing middle" between unit and e2e and must not silently absorb unit
@@ -23,11 +25,14 @@ const INTEGRATION_GLOB = '<rootDir>/tests/integration/**/*.integration.test.{ts,
 
 const EDGE_GLOB = '<rootDir>/src/test/edge/**/*.test.ts';
 
+const CONTRACT_GLOB = '<rootDir>/tests/contract/**/*.contract.test.ts';
+
 const testMatchByEnv: Record<string, string[]> = {
   server: ['<rootDir>/src/test/apollo-server**/*.test.ts', UNIT_GLOB],
   integration: [INTEGRATION_GLOB],
   client: ['<rootDir>/src/test/testing-library**/*.test.tsx', UNIT_GLOB],
   edge: [EDGE_GLOB],
+  contract: [CONTRACT_GLOB],
 };
 
 // Fail fast on an unrecognised TEST_ENV (e.g. a typo in a CI job) instead of
@@ -47,6 +52,7 @@ const isIntegration = TEST_ENV === 'integration';
 const isServer = TEST_ENV === 'server';
 const isEdge = TEST_ENV === 'edge';
 const isClient = TEST_ENV === 'client';
+const isContract = TEST_ENV === 'contract';
 
 // jsdom lacks the Fetch API; the integration layer drives the real Apollo
 // HttpLink, so it runs in a jsdom variant that injects Node's fetch globals.
@@ -107,15 +113,31 @@ const SERVER_COVERAGE_THRESHOLD = {
   global: { branches: 55, functions: 70, lines: 90, statements: 90 },
 };
 
+// The `contract` layer (#350) boots the Mockoon mock the e2e suite runs against
+// and holds every response against the committed user-service OpenAPI document.
+// Its subject is an HTTP mock's runtime behaviour, not repo source: it imports
+// nothing from `src/` except the swagger e2e fixtures it validates, so it is
+// isolated from the other layers exactly as `edge` is — a coverage threshold
+// here would measure the wrong thing, and folding it into `integration` would
+// dilute that layer's "exercise every shipped module" charter. The harness
+// itself is proven live by `parity-detects-drift.contract.test.ts`, which seeds
+// real defects into the mock data and asserts the gate turns red.
+
+const COVERAGE_DIRECTORY_BY_ENV: Record<string, string> = {
+  edge: 'coverage/edge',
+  contract: 'coverage/contract',
+};
+
 const config: Config = {
   clearMocks: true,
   // Generate the gitignored pages/i18n/localization.json (#328) before
   // jest.setup.ts imports the i18n stack that requires it.
   globalSetup: '<rootDir>/jest.global-setup.js',
   collectCoverage: true,
-  // The edge layer writes to its own coverage dir so its scripts-only report never
-  // clobbers the product coverage the client/server runs write to `coverage/`.
-  coverageDirectory: isEdge ? 'coverage/edge' : 'coverage',
+  // The edge and contract layers write to their own coverage dirs so their
+  // narrowly-scoped reports never clobber the product coverage the client/server
+  // runs write to `coverage/`.
+  coverageDirectory: COVERAGE_DIRECTORY_BY_ENV[TEST_ENV] ?? 'coverage',
   // The integration layer uses the `babel` coverage provider so coverage is
   // instrumented on the same babel-jest-transformed output the tests run
   // against; this keeps the strict 100% threshold measured against the exact
@@ -146,7 +168,8 @@ const config: Config = {
     '<rootDir>/src/test/testing-library/.*\\/utils\\.tsx$',
   ],
   preset: 'ts-jest',
-  testEnvironment: isServer || isEdge ? 'node' : isIntegration ? INTEGRATION_ENVIRONMENT : 'jsdom',
+  testEnvironment:
+    isServer || isEdge || isContract ? 'node' : isIntegration ? INTEGRATION_ENVIRONMENT : 'jsdom',
   transform: {
     '^.+\\.(js|jsx|mjs|cjs|ts|tsx)$': [
       'babel-jest',

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@memlab/api": "^2.0.3",
     "@memlab/heap-analysis": "^2.0.3",
     "@microsoft/api-extractor": "^7.58.7",
+    "@mockoon/commons": "9.2.0",
+    "@mockoon/commons-server": "9.2.0",
     "@next/bundle-analyzer": "^16.2.6",
     "@next/env": "^16.2.6",
     "@next/eslint-plugin-next": "^16.2.6",

--- a/scripts/ci/ensure-oasdiff.sh
+++ b/scripts/ci/ensure-oasdiff.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# Provision the pinned oasdiff CLI into ./bin (idempotent, SHA256-verified).
+#
+# oasdiff is a standalone Go binary, NOT an npm dependency: it is absent from the
+# node:*-alpine dev image, so it cannot run through PM_EXEC / the dev container.
+# This helper gives the nightly OpenAPI drift leg (and a local `make
+# lint-openapi`) a single, reproducible provisioning path to a gitignored ./bin.
+#
+# Mirrors scripts/ci/ensure-rca.sh deliberately — same pin-and-verify contract,
+# same install location, same idempotence check.
+set -eu
+
+OASDIFF_BIN="${OASDIFF_BIN:-./bin/oasdiff}"
+OASDIFF_VERSION="${OASDIFF_VERSION:-1.27.0}"
+OASDIFF_SHA256_LINUX="${OASDIFF_SHA256_LINUX:-335de79be8df706735f7ab3edc35186e853c8add93d489d67e4e7fd70a07d08a}"
+
+# Already the right version? Nothing to do (idempotent; no network needed).
+# -Fwq: fixed-string, whole-word match so e.g. 1.27.01 cannot satisfy 1.27.0.
+if [ -x "$OASDIFF_BIN" ] && "$OASDIFF_BIN" --version 2>/dev/null | grep -Fwq "$OASDIFF_VERSION"; then
+  exit 0
+fi
+
+# The pinned digest covers the linux/amd64 asset only. Every other platform would
+# need a different digest, so refuse rather than silently install an unverified
+# build — `make lint-openapi` is host-only and its CI home is a ubuntu runner.
+arch="$(uname -m)"
+os="$(uname -s)"
+if [ "$os" != "Linux" ] || { [ "$arch" != "x86_64" ] && [ "$arch" != "amd64" ]; }; then
+  printf 'ERROR: no verified oasdiff v%s asset pinned for %s/%s.\n' "$OASDIFF_VERSION" "$os" "$arch" >&2
+  printf 'Install oasdiff manually and point OASDIFF_BIN at it, or run the nightly workflow.\n' >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OASDIFF_BIN")"
+asset="oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
+url="https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/${asset}"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/oasdiff-install.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+curl -fsSL \
+  --retry 3 \
+  --retry-all-errors \
+  --connect-timeout 10 \
+  --max-time 120 \
+  "$url" -o "$tmp/$asset"
+printf '%s  %s\n' "$OASDIFF_SHA256_LINUX" "$tmp/$asset" | sha256sum -c -
+# The archive is flat: LICENSE + oasdiff at the root, no versioned directory.
+tar -xzf "$tmp/$asset" -C "$tmp"
+install -m 0755 "$tmp/oasdiff" "$OASDIFF_BIN"
+"$OASDIFF_BIN" --version

--- a/scripts/ci/openapi-drift.sh
+++ b/scripts/ci/openapi-drift.sh
@@ -95,7 +95,11 @@ printf '🔎 Comparing %s against %s@%s\n' "$OPENAPI_BASELINE" "$USER_SERVICE_RE
 
 report_dir="$(dirname "$OPENAPI_DRIFT_REPORT")"
 mkdir -p "$report_dir" 2>/dev/null || true
-[ -w "$report_dir" ] || fail "cannot write the drift report into $report_dir/"
+# `-d` as well as `-w`: a writable *regular file* at that path would pass a bare
+# `-w` and then fail the redirection below with exit 1 — indistinguishable from
+# "breaking drift found", which is the one thing this script must never confuse.
+{ [ -d "$report_dir" ] && [ -w "$report_dir" ]; } ||
+  fail "cannot write the drift report into $report_dir/"
 findings="$workdir/findings.md"
 
 # --fail-on ERR is what makes this a check at all: without it oasdiff prints
@@ -119,18 +123,30 @@ if [ "$status" -eq 0 ]; then
   exit 0
 fi
 
+pins="$(sed -n 's/^USER_SERVICE_VERSION=//p' .env 2>/dev/null || true)"
+pinned_ref="${pins%%$'\n'*}"
+
+# The prose is a QUOTED heredoc, not a series of single-quoted printfs: the text
+# is Markdown and full of backticks, which shellcheck reads inside single quotes
+# as a command substitution that will not expand (SC2016). A quoted heredoc is
+# literal by definition, so the warning is answered by construction rather than
+# suppressed — and the dynamic values stay in printf arguments, never inline.
 {
-  printf '## Upstream OpenAPI drift: `%s` → `%s`\n\n' \
-    "$(sed -n 's/^USER_SERVICE_VERSION=//p' .env 2>/dev/null | head -n 1)" "$upstream_ref"
-  printf 'The committed baseline `%s` no longer matches the newest `%s` release.\n' \
+  printf '## Upstream OpenAPI drift: %s -> %s\n\n' "${pinned_ref:-unknown}" "$upstream_ref"
+  printf 'The committed baseline %s no longer matches the newest %s release.\n' \
     "$OPENAPI_BASELINE" "$USER_SERVICE_REPO"
-  printf 'This is **advisory**: nothing is broken in this repository. It means the\n'
-  printf 'mock, the swagger page and the Apollo mock are pinned to an older contract.\n\n'
-  printf 'To adopt the new contract, bump `USER_SERVICE_VERSION` in `.env`, run\n'
-  printf '`make update-contracts`, then re-run `make test-contract` and `make test-e2e`.\n\n'
-  printf 'Breaking changes reported by `oasdiff breaking --fail-on ERR`:\n\n'
+  cat <<'PROSE'
+This is **advisory**: nothing is broken in this repository. It means the mock,
+the swagger page and the Apollo mock are pinned to an older contract.
+
+To adopt the new contract, bump `USER_SERVICE_VERSION` in `.env`, run
+`make update-contracts`, then re-run `make test-contract` and `make test-e2e`.
+
+Breaking changes reported by `oasdiff breaking --fail-on ERR`:
+
+PROSE
   cat "$findings"
-} >"$OPENAPI_DRIFT_REPORT"
+} >"$OPENAPI_DRIFT_REPORT" || fail "could not write the drift report to $OPENAPI_DRIFT_REPORT"
 
 printf '⚠️  Breaking changes found; report written to %s\n' "$OPENAPI_DRIFT_REPORT"
 exit "$EXIT_DRIFT"

--- a/scripts/ci/openapi-drift.sh
+++ b/scripts/ci/openapi-drift.sh
@@ -69,8 +69,16 @@ OASDIFF_BIN="$OASDIFF_BIN" sh "$(dirname "$0")/ensure-oasdiff.sh" ||
 # older than the newest release (v0.x). UPSTREAM_REF overrides it for testing.
 upstream_ref="${UPSTREAM_REF:-}"
 if [ -z "$upstream_ref" ]; then
-  upstream_ref="$(api "https://api.github.com/repos/${USER_SERVICE_REPO}/releases/latest" |
-    sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  # `|| fail` is load-bearing: without it `set -e` aborts the whole script with
+  # curl's own exit code (7 on a connection failure), which both skips the
+  # diagnostic below and breaks the documented three-way contract.
+  releases="$(api "https://api.github.com/repos/${USER_SERVICE_REPO}/releases/latest")" ||
+    fail "could not reach the ${USER_SERVICE_REPO} releases API"
+  # No `head`: a pipeline whose reader exits early would SIGPIPE the writer and,
+  # under `pipefail`, abort here for the same reason.
+  tags="$(printf '%s' "$releases" |
+    sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  upstream_ref="${tags%%$'\n'*}"
 fi
 [ -n "$upstream_ref" ] || fail "could not resolve the latest ${USER_SERVICE_REPO} release"
 

--- a/scripts/ci/openapi-drift.sh
+++ b/scripts/ci/openapi-drift.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Advisory upstream-drift check: does the committed OpenAPI baseline still
+# describe the same API contract as the newest user-service release? (issue #350)
+#
+# This is the nightly, ADVISORY leg. Upstream moving on is not a pull request
+# author's fault, so a breaking diff must never red a PR — the caller turns this
+# script's exit 1 into a tracking issue instead. The blocking leg is the
+# mock-vs-contract parity gate (`make test-contract`).
+#
+# The base is contracts/user-service/openapi.json — the same artifact
+# `make lint-contracts` drift-gates against USER_SERVICE_VERSION and the same one
+# Mockoon.Dockerfile serves. There is deliberately no second baseline file: a
+# copy would be a drift source with nothing watching it. Comparing the committed
+# (normalized, Prettier-formatted) JSON against raw upstream YAML is sound —
+# `scripts/fetchSwaggerSchema.mjs` only strips the invalid `maxLength: null` /
+# `format: null` keywords, which oasdiff does not diff on.
+#
+# Exit codes are deliberately three-way; a caller that treats "any non-zero" as
+# drift would report a network outage as a breaking API change:
+#   0 — no breaking change between the baseline and the upstream release
+#   1 — breaking changes found (report written to $OPENAPI_DRIFT_REPORT)
+#   2 — the check could not run (no network, bad tag, unreadable spec, tool misuse)
+#
+# CALL THIS SCRIPT DIRECTLY when you need those codes. GNU Make exits 2 on any
+# recipe failure and discards the recipe's own status, so the equivalent
+# `make lint-openapi` target cannot tell 1 from 2 — that target is the
+# human-facing surface, and .github/workflows/openapi-drift.yml invokes this
+# script instead so it can route drift and breakage differently.
+set -euo pipefail
+
+OASDIFF_BIN="${OASDIFF_BIN:-./bin/oasdiff}"
+OPENAPI_BASELINE="${OPENAPI_BASELINE:-contracts/user-service/openapi.json}"
+USER_SERVICE_REPO="${USER_SERVICE_REPO:-VilnaCRM-Org/user-service}"
+USER_SERVICE_SPEC_PATH="${USER_SERVICE_SPEC_PATH:-.github/openapi-spec/spec.yaml}"
+OPENAPI_DRIFT_REPORT="${OPENAPI_DRIFT_REPORT:-reports/openapi-drift.md}"
+
+readonly EXIT_DRIFT=1
+readonly EXIT_UNAVAILABLE=2
+
+fail() {
+  printf '❌ %s\n' "$1" >&2
+  exit "$EXIT_UNAVAILABLE"
+}
+
+api() {
+  # A token is optional (the endpoints are public) but lifts the anonymous rate
+  # limit, which a scheduled runner shares with every other job on its IP.
+  if [ -n "${GH_TOKEN:-}" ]; then
+    curl -fsSL --retry 3 --retry-all-errors --connect-timeout 10 --max-time 60 \
+      -H "Authorization: Bearer ${GH_TOKEN}" \
+      -H 'Accept: application/vnd.github+json' "$1"
+  else
+    curl -fsSL --retry 3 --retry-all-errors --connect-timeout 10 --max-time 60 \
+      -H 'Accept: application/vnd.github+json' "$1"
+  fi
+}
+
+# Idempotent: a no-op once the pinned, digest-verified binary is in ./bin. Kept
+# inside this script so `make lint-openapi` and the nightly workflow provision it
+# through exactly one path.
+OASDIFF_BIN="$OASDIFF_BIN" sh "$(dirname "$0")/ensure-oasdiff.sh" ||
+  fail 'could not provision the pinned oasdiff binary'
+
+[ -x "$OASDIFF_BIN" ] || fail "oasdiff is not installed at $OASDIFF_BIN"
+[ -r "$OPENAPI_BASELINE" ] || fail "baseline $OPENAPI_BASELINE is missing or unreadable"
+
+# "Latest release" is resolved from the releases API, not by semver-sorting tags:
+# upstream restarted its numbering, so the newest tag by semver (v2.x) is a year
+# older than the newest release (v0.x). UPSTREAM_REF overrides it for testing.
+upstream_ref="${UPSTREAM_REF:-}"
+if [ -z "$upstream_ref" ]; then
+  upstream_ref="$(api "https://api.github.com/repos/${USER_SERVICE_REPO}/releases/latest" |
+    sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+fi
+[ -n "$upstream_ref" ] || fail "could not resolve the latest ${USER_SERVICE_REPO} release"
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/openapi-drift.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT INT TERM
+revision="$workdir/upstream-${upstream_ref}.yaml"
+
+spec_url="https://raw.githubusercontent.com/${USER_SERVICE_REPO}/${upstream_ref}/${USER_SERVICE_SPEC_PATH}"
+curl -fsSL --retry 3 --retry-all-errors --connect-timeout 10 --max-time 60 "$spec_url" -o "$revision" ||
+  fail "could not fetch $spec_url — has the spec moved in $upstream_ref?"
+[ -s "$revision" ] || fail "$spec_url returned an empty document"
+
+printf '🔎 Comparing %s against %s@%s\n' "$OPENAPI_BASELINE" "$USER_SERVICE_REPO" "$upstream_ref"
+
+report_dir="$(dirname "$OPENAPI_DRIFT_REPORT")"
+mkdir -p "$report_dir" 2>/dev/null || true
+[ -w "$report_dir" ] || fail "cannot write the drift report into $report_dir/"
+findings="$workdir/findings.md"
+
+# --fail-on ERR is what makes this a check at all: without it oasdiff prints
+# every breaking change and still exits 0. --allow-external-refs=false stops a
+# $ref in the fetched document from driving an outbound request from the runner.
+set +e
+"$OASDIFF_BIN" breaking "$OPENAPI_BASELINE" "$revision" \
+  --fail-on ERR \
+  --allow-external-refs=false \
+  --format markdown >"$findings" 2>"$workdir/stderr"
+status=$?
+set -e
+
+if [ "$status" -ne 0 ] && [ "$status" -ne "$EXIT_DRIFT" ]; then
+  cat "$workdir/stderr" >&2
+  fail "oasdiff exited $status — it could not compare the documents (this is not a drift report)"
+fi
+
+if [ "$status" -eq 0 ]; then
+  printf '✅ No breaking changes between the baseline and %s\n' "$upstream_ref"
+  exit 0
+fi
+
+{
+  printf '## Upstream OpenAPI drift: `%s` → `%s`\n\n' \
+    "$(sed -n 's/^USER_SERVICE_VERSION=//p' .env 2>/dev/null | head -n 1)" "$upstream_ref"
+  printf 'The committed baseline `%s` no longer matches the newest `%s` release.\n' \
+    "$OPENAPI_BASELINE" "$USER_SERVICE_REPO"
+  printf 'This is **advisory**: nothing is broken in this repository. It means the\n'
+  printf 'mock, the swagger page and the Apollo mock are pinned to an older contract.\n\n'
+  printf 'To adopt the new contract, bump `USER_SERVICE_VERSION` in `.env`, run\n'
+  printf '`make update-contracts`, then re-run `make test-contract` and `make test-e2e`.\n\n'
+  printf 'Breaking changes reported by `oasdiff breaking --fail-on ERR`:\n\n'
+  cat "$findings"
+} >"$OPENAPI_DRIFT_REPORT"
+
+printf '⚠️  Breaking changes found; report written to %s\n' "$OPENAPI_DRIFT_REPORT"
+exit "$EXIT_DRIFT"

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -68,11 +68,14 @@ stop	bats	tests/bats/makefile_targets.bats	Validated with a stubbed Docker Compo
 check-node-version	bats	tests/bats/makefile_targets.bats	Validated with a stubbed node invocation.
 lint-deps	ci	.github/workflows/static-testing.yml	Executed through `make lint`, which depends on `lint-deps`.
 lint-contracts	bats	tests/bats/makefile_targets.bats	Executed directly by contract-testing.yml; deliberately outside `make lint` because the drift check needs network.
+lint-openapi	bats	tests/bats/makefile_targets.bats	Validated host-only: ensure-oasdiff.sh provisioning (idempotent) plus openapi-drift.sh three-way exit handling with a stubbed oasdiff binary.
 update-contracts	bats	tests/bats/makefile_targets.bats	Maintainer command for bumping USER_SERVICE_VERSION; refreshes both artifacts and the spectral baseline.
 run-deps-lint-tests-dind	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker exec calls.
 test-integration	bats	tests/bats/makefile_targets.bats	Validated by invoking Jest with TEST_ENV=integration through a stubbed jest binary.
 test-integration-watch	bats	tests/bats/makefile_targets.bats	Validated by invoking Jest in watch mode with TEST_ENV=integration through a stubbed jest binary.
 ci-test-integration	ci	.github/workflows/integration-testing.yml	Executed directly by the integration testing workflow.
+test-contract	bats	tests/bats/makefile_targets.bats	Validated by invoking Jest with TEST_ENV=contract through a stubbed jest binary.
+ci-test-contract	ci	.github/workflows/contract-parity-testing.yml	Executed directly by the contract parity testing workflow.
 ci-setup	bats	tests/bats/makefile_targets.bats	Validated by bringing up the stubbed dev service and asserting the readiness wait.
 ci-lint	bats	tests/bats/makefile_targets.bats	Validated by running the parallel lint runner against stubbed make targets.
 ci-test	bats	tests/bats/makefile_targets.bats	Validated by running the parallel dev-side test runner against stubbed make targets.

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -339,6 +339,7 @@ STUB
   assert_output_contains '===== ci-test-unit-client ====='
   assert_output_contains '===== ci-test-unit-server ====='
   assert_output_contains '===== ci-test-integration ====='
+  assert_output_contains '===== ci-test-contract ====='
 }
 
 @test "ci-test split targets invoke Jest directly with the right TEST_ENV" {

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -297,6 +297,19 @@ STUB
   assert_log_contains 'jest TEST_ENV=integration --watch'
 }
 
+@test "test-contract runs Jest in the contract environment" {
+  cat > "$STUB_BIN_DIR/jest" <<'STUB'
+#!/usr/bin/env bash
+printf 'jest TEST_ENV=%s %s\n' "${TEST_ENV:-unset}" "$*" >> "${COMMAND_LOG:?}"
+exit 0
+STUB
+  chmod +x "$STUB_BIN_DIR/jest"
+
+  run_make_target test-contract CI=1
+  [ "$status" -eq 0 ]
+  assert_log_contains 'jest TEST_ENV=contract --verbose'
+}
+
 @test "ensure-dev starts the dev service when it is not already running" {
   run_make_target ensure-dev CI=1
   [ "$status" -eq 0 ]
@@ -491,6 +504,115 @@ STUB
   # Host-only: never routed through the dev container (docker) or the package manager (bun).
   run grep -E 'docker|bun' "$COMMAND_LOG"
   [ "$status" -ne 0 ]
+}
+
+# Provisions the lint-openapi sandbox: an already-installed oasdiff stub whose
+# `breaking` exit code the caller chooses, the committed baseline, and a curl
+# stub that "downloads" the upstream spec. UPSTREAM_REF short-circuits the
+# releases-API lookup, so the target is exercised without touching the network.
+setup_openapi_drift_sandbox() {
+  local breaking_exit="$1"
+
+  reset_command_log
+
+  mkdir -p "$MAKEFILE_SANDBOX/bin"
+  cat > "$MAKEFILE_SANDBOX/bin/oasdiff" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "--version" ]; then
+  echo "oasdiff version 1.27.0"
+  exit 0
+fi
+echo 'stubbed oasdiff output'
+exit ${breaking_exit}
+STUB
+  chmod +x "$MAKEFILE_SANDBOX/bin/oasdiff"
+
+  mkdir -p "$MAKEFILE_SANDBOX/contracts/user-service"
+  cp "$PROJECT_ROOT/contracts/user-service/openapi.json" \
+    "$MAKEFILE_SANDBOX/contracts/user-service/"
+
+  cat > "$STUB_BIN_DIR/curl" <<'STUB'
+#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >> "${COMMAND_LOG:?}"
+destination=""
+previous=""
+for argument in "$@"; do
+  [ "$previous" = "-o" ] && destination="$argument"
+  previous="$argument"
+done
+if [ -n "$destination" ] && [ -n "${STUB_SPEC_SOURCE:-}" ]; then
+  cp "$STUB_SPEC_SOURCE" "$destination"
+fi
+exit 0
+STUB
+  chmod +x "$STUB_BIN_DIR/curl"
+
+  export STUB_SPEC_SOURCE="$MAKEFILE_SANDBOX/contracts/user-service/openapi.json"
+  export UPSTREAM_REF="v0.0.0-stub"
+}
+
+# GNU make collapses every recipe failure to its own exit 2, so the three-way
+# contract can only be asserted against the script. openapi-drift.yml calls it
+# the same way for the same reason.
+run_openapi_drift_script() {
+  run env -C "$MAKEFILE_SANDBOX" \
+    PATH="$STUB_BIN_DIR:$PATH" \
+    COMMAND_LOG="$COMMAND_LOG" \
+    OASDIFF_BIN="./bin/oasdiff" \
+    STUB_SPEC_SOURCE="$STUB_SPEC_SOURCE" \
+    UPSTREAM_REF="$UPSTREAM_REF" \
+    bash scripts/ci/openapi-drift.sh
+}
+
+@test "lint-openapi provisions the pinned oasdiff then reports a clean baseline host-only" {
+  setup_openapi_drift_sandbox 0
+
+  run_make_target lint-openapi
+  [ "$status" -eq 0 ]
+  assert_output_contains 'No breaking changes'
+
+  # Host-only: never routed through the dev container (docker) or the package manager (bun).
+  run grep -E 'docker|bun' "$COMMAND_LOG"
+  [ "$status" -ne 0 ]
+}
+
+@test "the drift script writes a report and exits 1 when upstream has breaking changes" {
+  setup_openapi_drift_sandbox 1
+
+  run_openapi_drift_script
+  [ "$status" -eq 1 ]
+  assert_output_contains 'Breaking changes found'
+  [ -s "$MAKEFILE_SANDBOX/reports/openapi-drift.md" ]
+}
+
+@test "the drift script reports a tool failure as unavailable, never as drift" {
+  # oasdiff exits 100 on flag misuse and 102 when it cannot load a spec. Either
+  # must surface as "unavailable" (2), never as an upstream API change (1) —
+  # otherwise a broken nightly is indistinguishable from a clean one.
+  setup_openapi_drift_sandbox 100
+
+  run_openapi_drift_script
+  [ "$status" -eq 2 ]
+  assert_output_contains 'this is not a drift report'
+}
+
+@test "the oasdiff pin is identical in the Makefile and its provisioning script" {
+  # The Makefile documents the pin at the top and passes it down; the script
+  # carries the same values as defaults so the nightly, which calls the script
+  # directly, provisions the very same verified binary. They must never drift.
+  local makefile_version script_version makefile_digest script_digest
+
+  makefile_version="$(sed -n 's/^OASDIFF_VERSION[[:space:]]*=[[:space:]]*//p' "$PROJECT_ROOT/Makefile")"
+  makefile_digest="$(sed -n 's/^OASDIFF_SHA256_LINUX[[:space:]]*=[[:space:]]*//p' "$PROJECT_ROOT/Makefile")"
+  script_version="$(sed -n 's/^OASDIFF_VERSION="\${OASDIFF_VERSION:-\(.*\)}"$/\1/p' \
+    "$PROJECT_ROOT/scripts/ci/ensure-oasdiff.sh")"
+  script_digest="$(sed -n 's/^OASDIFF_SHA256_LINUX="\${OASDIFF_SHA256_LINUX:-\(.*\)}"$/\1/p' \
+    "$PROJECT_ROOT/scripts/ci/ensure-oasdiff.sh")"
+
+  [ -n "$makefile_version" ]
+  [ -n "$makefile_digest" ]
+  [ "$makefile_version" = "$script_version" ]
+  [ "$makefile_digest" = "$script_digest" ]
 }
 
 @test "contract targets shell out to Node and cover fetch, lint and baseline refresh" {

--- a/tests/contract/mockoon-openapi-parity.contract.test.ts
+++ b/tests/contract/mockoon-openapi-parity.contract.test.ts
@@ -21,7 +21,7 @@
  */
 import Ajv2020 from 'ajv/dist/2020';
 
-import { MOCK_API_USER, MOCK_API_USERS } from '../../src/test/e2e/swagger/utils/constants';
+import { MOCK_API_USER, MOCK_API_USERS } from '@/test/e2e/swagger/utils/constants';
 
 import { replayOperation, startMockoon, type MockoonHandle } from './utils/mockoon-harness';
 import {
@@ -110,18 +110,26 @@ describe('the swagger e2e fixtures describe a user the contract still documents'
   // drift class, one layer up from the mock.
   const listUsers = findOperation(contract, 'get', '/api/users');
   const collectionSchema = listUsers && responseSchema(listUsers.operation, '200');
+  const itemSchema = collectionSchema?.items;
 
-  it('exposes the GET /api/users 200 schema the fixtures are held against', () => {
+  it('exposes the GET /api/users 200 item schema the fixtures are held against', () => {
+    // Both assertions below reach through `.items`. Guarding only the
+    // collection would let them pass vacuously the day upstream drops it —
+    // the undeclared-property rule would stop checking the user shape while
+    // reporting green, which is the regression this gate exists to catch.
     expect(collectionSchema).toBeDefined();
+    expect(itemSchema).toBeDefined();
   });
 
   it('validates MOCK_API_USERS against that schema', () => {
-    const validate = ajv.compile(collectionSchema ?? {});
+    // No `?? {}` fallback: an empty schema validates anything, so a missing
+    // schema would turn this into an assertion that always passes.
+    const validate = ajv.compile(collectionSchema as object);
 
     expect(validate(MOCK_API_USERS) ? '' : ajv.errorsText(validate.errors)).toBe('');
   });
 
   it('declares every property the ApiUser fixture carries', () => {
-    expect(undeclaredProperties(collectionSchema?.items, MOCK_API_USER)).toEqual([]);
+    expect(undeclaredProperties(itemSchema, MOCK_API_USER)).toEqual([]);
   });
 });

--- a/tests/contract/mockoon-openapi-parity.contract.test.ts
+++ b/tests/contract/mockoon-openapi-parity.contract.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ *
+ * Contract: the Mockoon mock the e2e suite runs against still matches the
+ * committed user-service OpenAPI contract (issue #350).
+ *
+ * The whole Playwright suite talks to Mockoon, so nothing else in this repo
+ * checks that the mocked responses still match the API's documented shape — the
+ * mock could rot indefinitely while e2e stayed green and the mismatch surfaced
+ * only in production (issue #243 / PR #245 is the recorded instance of exactly
+ * that class). This spec boots the same mock from the same data file, replays
+ * every documented operation, and holds each response against the contract.
+ *
+ * Scenario coverage (agents.md step 2):
+ *   - Positive — every documented operation replayed against the live mock.
+ *   - Negative / boundary — `parity-detects-drift.contract.test.ts` seeds a
+ *     renamed field, a retyped field, an extra field and a removed status into
+ *     the mock data and asserts each turns this gate red.
+ *   - Locale / responsive / a11y — Not applicable: this layer observes an HTTP
+ *     mock's wire format, which has no rendered UI and no localized text.
+ */
+import Ajv2020 from 'ajv/dist/2020';
+
+import { MOCK_API_USER, MOCK_API_USERS } from '../../src/test/e2e/swagger/utils/constants';
+
+import { replayOperation, startMockoon, type MockoonHandle } from './utils/mockoon-harness';
+import {
+  CONTRACT_PATH,
+  findOperation,
+  listOperations,
+  readContract,
+  responseSchema,
+  type ContractOperation,
+} from './utils/openapi-contract';
+import { checkResponseParity, formatProblems, undeclaredProperties } from './utils/response-parity';
+
+const BOOT_TIMEOUT_MS = 30_000;
+
+const contract = readContract();
+const operations = listOperations(contract);
+
+// `strict: false` because OpenAPI schemas legitimately carry annotation
+// keywords (`example`, `deprecated`) that ajv's strict mode rejects as unknown.
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+
+let mockoon: MockoonHandle;
+
+beforeAll(async () => {
+  mockoon = await startMockoon(CONTRACT_PATH);
+}, BOOT_TIMEOUT_MS);
+
+afterAll(async () => {
+  await mockoon?.stop();
+});
+
+describe('the committed contract is shaped the way this gate assumes', () => {
+  it('declares at least one replayable operation', () => {
+    // Mirrors the "no gql documents found — the extractor is broken" guard in
+    // lint-contracts.mjs: an empty operation list would make every assertion
+    // below pass vacuously.
+    expect(operations.length).toBeGreaterThan(0);
+  });
+
+  it('inlines every schema, so validation needs no $ref resolver', () => {
+    // ajv is handed each response schema on its own. A `$ref` would silently
+    // fail to resolve, so the day upstream introduces one this must fail loudly
+    // rather than quietly stop validating.
+    expect(JSON.stringify(contract)).not.toContain('"$ref"');
+  });
+});
+
+describe('Mockoon serves what the contract documents', () => {
+  it.each(operations.map((operation): [string, ContractOperation] => [operation.label, operation]))(
+    '%s',
+    async (label, operation) => {
+      const observed = await replayOperation(mockoon.baseUrl, operation);
+      const problems = checkResponseParity(operation, observed, ajv);
+
+      expect(formatProblems(label, problems)).toBe('');
+    }
+  );
+});
+
+describe('the swagger e2e fixtures describe a user the contract still documents', () => {
+  // src/test/e2e/swagger/utils/constants.ts hard-codes the user shape the
+  // Playwright specs assert against. If upstream renames or drops a field, the
+  // fixture keeps e2e green against a shape the API no longer has — the same
+  // drift class, one layer up from the mock.
+  const listUsers = findOperation(contract, 'get', '/api/users');
+  const collectionSchema = listUsers && responseSchema(listUsers.operation, '200');
+
+  it('exposes the GET /api/users 200 schema the fixtures are held against', () => {
+    expect(collectionSchema).toBeDefined();
+  });
+
+  it('validates MOCK_API_USERS against that schema', () => {
+    const validate = ajv.compile(collectionSchema ?? {});
+
+    expect(validate(MOCK_API_USERS) ? '' : ajv.errorsText(validate.errors)).toBe('');
+  });
+
+  it('declares every property the ApiUser fixture carries', () => {
+    expect(undeclaredProperties(collectionSchema?.items, MOCK_API_USER)).toEqual([]);
+  });
+});

--- a/tests/contract/mockoon-openapi-parity.contract.test.ts
+++ b/tests/contract/mockoon-openapi-parity.contract.test.ts
@@ -30,6 +30,7 @@ import {
   listOperations,
   readContract,
   responseSchema,
+  unsupportedResponseConstructs,
   type ContractOperation,
 } from './utils/openapi-contract';
 import { checkResponseParity, formatProblems, undeclaredProperties } from './utils/response-parity';
@@ -61,11 +62,32 @@ describe('the committed contract is shaped the way this gate assumes', () => {
     expect(operations.length).toBeGreaterThan(0);
   });
 
-  it('inlines every schema, so validation needs no $ref resolver', () => {
-    // ajv is handed each response schema on its own. A `$ref` would silently
-    // fail to resolve, so the day upstream introduces one this must fail loudly
-    // rather than quietly stop validating.
-    expect(JSON.stringify(contract)).not.toContain('"$ref"');
+  it('still routes at least as many operations through full body validation', () => {
+    // Mockoon serves the FIRST response an operation declares, so only that one
+    // is ever observed — and of those, only the schema-bearing ones reach the
+    // schema and undeclared-property rules. Today 7 of 12 do; the rest declare
+    // `example: ""` with no schema, or are bodyless 204s.
+    //
+    // This is a ratchet, not a target. Without it the gate could quietly shrink
+    // to validating nothing — an upstream reorder that put a schema-less
+    // response first on every operation would leave every assertion green.
+    // Raise the floor when the count rises; never lower it.
+    const withSchema = operations.filter(({ operation }) => {
+      const first = Object.keys(operation.responses ?? {})[0];
+      return first !== undefined && responseSchema(operation, first) !== undefined;
+    });
+
+    expect(withSchema.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('uses only response-schema constructs the parity rules can reason about', () => {
+    // ajv is handed each response schema on its own, with no resolver, and the
+    // undeclared-property rule walks `properties`/`items` only. A `$ref`, or a
+    // schema composed through `allOf`/`oneOf`/`prefixItems`/…, would make the
+    // gate quietly validate less while still reporting green — so the day
+    // `make update-contracts` pulls a spec that uses one, this must fail loudly.
+    // Extend the rules (never this list) when that day comes.
+    expect(unsupportedResponseConstructs(contract)).toEqual([]);
   });
 });
 

--- a/tests/contract/mockoon-pin-parity.contract.test.ts
+++ b/tests/contract/mockoon-pin-parity.contract.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ *
+ * Contract: the Mockoon the parity gate boots is the Mockoon the e2e suite gets.
+ *
+ * `Mockoon.Dockerfile` installs `@mockoon/cli` globally; the parity gate drives
+ * `@mockoon/commons-server` in-process (the libraries that CLI is a wrapper
+ * over). Mockoon's OpenAPI conversion lives in those libraries, so if the two
+ * pins drift the gate would certify a mock the e2e stack never runs — the exact
+ * failure mode issue #350 exists to prevent, reintroduced one level down.
+ *
+ * The fix for a red run here is to move BOTH pins together, never to relax this
+ * assertion. `@mockoon/cli` depends on an exact (`=`) `@mockoon/commons-server`
+ * of the same version, so "same version string" is the right invariant.
+ *
+ * Scenario coverage (agents.md step 2):
+ *   - Positive — the pins agree today.
+ *   - Negative — the parse guards below fail loudly if the pin can no longer be
+ *     read (a reworded Dockerfile line, a moved dependency), rather than
+ *     silently comparing `undefined` to `undefined`.
+ *   - Boundary / locale / a11y — Not applicable: this compares two version
+ *     strings in committed files.
+ */
+import { readFileSync } from 'node:fs';
+
+const MOCKOON_DOCKERFILE = 'Mockoon.Dockerfile';
+const MOCKOON_LIBRARIES = ['@mockoon/commons', '@mockoon/commons-server'] as const;
+
+interface PackageManifest {
+  readonly devDependencies?: Readonly<Record<string, string>>;
+}
+
+function cliVersionFromDockerfile(): string {
+  const dockerfile = readFileSync(MOCKOON_DOCKERFILE, 'utf8');
+  const pin = /@mockoon\/cli@(\d+\.\d+\.\d+)/.exec(dockerfile);
+
+  if (pin?.[1] === undefined) {
+    throw new Error(`${MOCKOON_DOCKERFILE} no longer pins @mockoon/cli@<version>`);
+  }
+  return pin[1];
+}
+
+describe('the mocked API is pinned to one Mockoon version', () => {
+  const manifest = JSON.parse(readFileSync('package.json', 'utf8')) as PackageManifest;
+  const cliVersion = cliVersionFromDockerfile();
+
+  it.each(MOCKOON_LIBRARIES)('%s matches the CLI version the e2e image installs', library => {
+    // Exact pins only: a range would let the gate and the image resolve
+    // different builds of the same conversion code.
+    expect(manifest.devDependencies?.[library]).toBe(cliVersion);
+  });
+});

--- a/tests/contract/mockoon-pin-parity.contract.test.ts
+++ b/tests/contract/mockoon-pin-parity.contract.test.ts
@@ -32,12 +32,18 @@ interface PackageManifest {
 
 function cliVersionFromDockerfile(): string {
   const dockerfile = readFileSync(MOCKOON_DOCKERFILE, 'utf8');
-  const pin = /@mockoon\/cli@(\d+\.\d+\.\d+)/.exec(dockerfile);
+  // Capture the WHOLE version token, not `\d+\.\d+\.\d+`: a narrow pattern
+  // matches the `9.3.0` prefix of `9.3.0-beta.1` and would call a pre-release
+  // image equal to a released library. Requiring exactly one occurrence stops
+  // a second, unpinned `@mockoon/cli@…` line from hiding behind the first.
+  const pins = [...dockerfile.matchAll(/@mockoon\/cli@([^\s"'\\]+)/g)].map(match => match[1]);
 
-  if (pin?.[1] === undefined) {
-    throw new Error(`${MOCKOON_DOCKERFILE} no longer pins @mockoon/cli@<version>`);
+  if (pins.length !== 1 || pins[0] === undefined) {
+    throw new Error(
+      `${MOCKOON_DOCKERFILE} must pin @mockoon/cli@<version> exactly once, found ${pins.length}`
+    );
   }
-  return pin[1];
+  return pins[0];
 }
 
 describe('the mocked API is pinned to one Mockoon version', () => {

--- a/tests/contract/parity-detects-drift.contract.test.ts
+++ b/tests/contract/parity-detects-drift.contract.test.ts
@@ -21,7 +21,7 @@
  *     against `checkResponseParity`.
  *   - Positive — covered by `mockoon-openapi-parity.contract.test.ts`.
  */
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -57,6 +57,12 @@ let workDir: string;
 
 beforeAll(() => {
   workDir = mkdtempSync(path.join(tmpdir(), 'mockoon-parity-'));
+});
+
+afterAll(() => {
+  // Each case writes a full copy of the contract; without this the directories
+  // accumulate in $TMPDIR on every local run and on self-hosted runners.
+  rmSync(workDir, { recursive: true, force: true });
 });
 
 /** A mutable deep copy of the contract, used as corrupted *mock data* only. */

--- a/tests/contract/parity-detects-drift.contract.test.ts
+++ b/tests/contract/parity-detects-drift.contract.test.ts
@@ -181,9 +181,6 @@ describe('the unsupported-construct tripwire is precise in both directions', () 
     return unsupportedResponseConstructs(copy as unknown as OpenApiDocument);
   };
 
-  const itemProps = (document: MutableDocument): Record<string, SchemaObject> =>
-    itemProperties(document);
-
   const mediaType = (document: MutableDocument): Record<string, unknown> =>
     (
       document.paths['/api/users']!.get!.responses['200'] as {
@@ -197,7 +194,7 @@ describe('the unsupported-construct tripwire is precise in both directions', () 
 
   it('does not flag a property whose NAME is a schema keyword', () => {
     expect(
-      mutated(document => Object.assign(itemProps(document), { allOf: { type: 'string' } }))
+      mutated(document => Object.assign(itemProperties(document), { allOf: { type: 'string' } }))
     ).toEqual([]);
   });
 
@@ -206,14 +203,16 @@ describe('the unsupported-construct tripwire is precise in both directions', () 
       mutated(document => Object.assign(mediaType(document), { example: [{ allOf: 'x' }] }))
     ).toEqual([]);
     expect(
-      mutated(document => Object.assign(itemProps(document).email!, { enum: [{ oneOf: 'x' }] }))
+      mutated(document =>
+        Object.assign(itemProperties(document).email!, { enum: [{ oneOf: 'x' }] })
+      )
     ).toEqual([]);
   });
 
   it('flags a real sub-schema nested under a property named `example`', () => {
     expect(
       mutated(document =>
-        Object.assign(itemProps(document), { example: { oneOf: [{ type: 'string' }] } })
+        Object.assign(itemProperties(document), { example: { oneOf: [{ type: 'string' }] } })
       )
     ).toHaveLength(1);
   });
@@ -226,7 +225,7 @@ describe('the unsupported-construct tripwire is precise in both directions', () 
     ).toHaveLength(1);
     expect(
       mutated(document =>
-        Object.assign(itemProps(document), { email: { oneOf: [{ type: 'string' }] } })
+        Object.assign(itemProperties(document), { email: { oneOf: [{ type: 'string' }] } })
       )
     ).toHaveLength(1);
     expect(

--- a/tests/contract/parity-detects-drift.contract.test.ts
+++ b/tests/contract/parity-detects-drift.contract.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment node
+ *
+ * Contract: the parity gate actually bites (issue #350's third acceptance
+ * criterion — "the check has failed at least once on a deliberately seeded
+ * defect").
+ *
+ * A gate nobody has ever seen fail is indistinguishable from a gate that cannot
+ * fail, so the seeded defect is committed and repeatable rather than a one-off
+ * manual experiment. Each case writes a corrupted **copy** of the mock data,
+ * boots Mockoon on it, and checks the responses against the **pristine**
+ * contract — which is why `startMockoon` and `checkResponseParity` take the mock
+ * and the contract as separate inputs even though production passes the same
+ * file to both.
+ *
+ * Scenario coverage (agents.md step 2):
+ *   - Negative — a renamed, retyped and added response field, plus an
+ *     undocumented status, each replayed through the real mock.
+ *   - Boundary — the rules that Mockoon cannot be made to produce (a malformed
+ *     body, an empty body under a schema-bearing response) are driven directly
+ *     against `checkResponseParity`.
+ *   - Positive — covered by `mockoon-openapi-parity.contract.test.ts`.
+ */
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import Ajv2020 from 'ajv/dist/2020';
+
+import { replayOperation, startMockoon } from './utils/mockoon-harness';
+import {
+  findOperation,
+  readContract,
+  type ContractOperation,
+  type SchemaObject,
+} from './utils/openapi-contract';
+import {
+  checkResponseParity,
+  type ParityProblemKind,
+  type ObservedResponse,
+} from './utils/response-parity';
+
+const SEED_TIMEOUT_MS = 30_000;
+
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+const contract = readContract();
+
+const listUsers = findOperation(contract, 'get', '/api/users');
+if (listUsers === undefined) {
+  throw new Error(
+    'GET /api/users is missing from the contract — the seeded-defect cases assume it'
+  );
+}
+const LIST_USERS: ContractOperation = listUsers;
+
+let workDir: string;
+
+beforeAll(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), 'mockoon-parity-'));
+});
+
+/** A mutable deep copy of the contract, used as corrupted *mock data* only. */
+type MutableDocument = {
+  paths: Record<string, Record<string, { responses: Record<string, unknown> }>>;
+};
+
+/** The response-item properties the seeded mutations rewrite. */
+function itemProperties(document: MutableDocument): Record<string, SchemaObject> {
+  const response = document.paths['/api/users']?.get?.responses['200'] as {
+    content: Record<string, { schema: { items: { properties: Record<string, SchemaObject> } } }>;
+  };
+  return response.content['application/json']!.schema.items.properties;
+}
+
+/** Serialises a corrupted copy of the mock data and boots Mockoon on it. */
+async function replayCorruptedMock(
+  name: string,
+  corrupt: (document: MutableDocument) => void
+): Promise<ObservedResponse> {
+  const corrupted = JSON.parse(JSON.stringify(contract)) as MutableDocument;
+  corrupt(corrupted);
+
+  const dataFile = path.join(workDir, `${name}.json`);
+  writeFileSync(dataFile, JSON.stringify(corrupted));
+
+  const mockoon = await startMockoon(dataFile);
+  try {
+    return await replayOperation(mockoon.baseUrl, LIST_USERS);
+  } finally {
+    await mockoon.stop();
+  }
+}
+
+async function seededProblemKinds(
+  name: string,
+  corrupt: (document: MutableDocument) => void
+): Promise<ParityProblemKind[]> {
+  const observed = await replayCorruptedMock(name, corrupt);
+  return checkResponseParity(LIST_USERS, observed, ajv).map(({ kind }) => kind);
+}
+
+describe('a seeded defect in the mock data turns the gate red', () => {
+  it(
+    'catches a renamed response field',
+    async () => {
+      // The issue's own worked example. Note ajv alone does NOT catch this: the
+      // upstream document misplaces `required` on the array schema instead of
+      // on its `items`, so only the undeclared-property rule sees the rename.
+      const kinds = await seededProblemKinds('renamed-field', document => {
+        const properties = itemProperties(document);
+        properties.emailAddress = properties.email!;
+        delete properties.email;
+      });
+
+      expect(kinds).toContain('undeclared-property');
+    },
+    SEED_TIMEOUT_MS
+  );
+
+  it(
+    'catches a retyped response field',
+    async () => {
+      const kinds = await seededProblemKinds('retyped-field', document => {
+        itemProperties(document).confirmed = { type: 'string' };
+      });
+
+      expect(kinds).toContain('schema-violation');
+    },
+    SEED_TIMEOUT_MS
+  );
+
+  it(
+    'catches a response field the contract never declares',
+    async () => {
+      const kinds = await seededProblemKinds('added-field', document => {
+        itemProperties(document).unexpected = { type: 'string' };
+      });
+
+      expect(kinds).toContain('undeclared-property');
+    },
+    SEED_TIMEOUT_MS
+  );
+
+  it(
+    'catches a status the contract does not document',
+    async () => {
+      const kinds = await seededProblemKinds('moved-status', document => {
+        const { responses } = document.paths['/api/users']!.get!;
+        responses['299'] = responses['200']!;
+        delete responses['200'];
+      });
+
+      expect(kinds).toEqual(['undocumented-status']);
+    },
+    SEED_TIMEOUT_MS
+  );
+});
+
+describe('the rules Mockoon cannot be made to produce', () => {
+  const deleteUser = findOperation(contract, 'delete', '/api/users/{id}');
+
+  const observe = (overrides: Partial<ObservedResponse>): ObservedResponse => ({
+    status: 200,
+    contentType: 'application/json',
+    body: '[]',
+    ...overrides,
+  });
+
+  const kindsFor = (
+    operation: ContractOperation,
+    observed: ObservedResponse
+  ): ParityProblemKind[] => checkResponseParity(operation, observed, ajv).map(({ kind }) => kind);
+
+  it('rejects a body that is not parseable as its declared media type', () => {
+    expect(kindsFor(LIST_USERS, observe({ body: '<html>not json</html>' }))).toEqual([
+      'malformed-body',
+    ]);
+  });
+
+  it('rejects an empty body where the contract declares a schema', () => {
+    expect(kindsFor(LIST_USERS, observe({ body: '' }))).toEqual(['schema-violation']);
+  });
+
+  it('rejects a media type the status does not declare', () => {
+    expect(kindsFor(LIST_USERS, observe({ contentType: 'application/xml' }))).toEqual([
+      'undocumented-media-type',
+    ]);
+  });
+
+  it('rejects a status the operation does not document', () => {
+    expect(kindsFor(LIST_USERS, observe({ status: 418 }))).toEqual(['undocumented-status']);
+  });
+
+  it('rejects a body on a status that must not carry one', () => {
+    // DELETE /api/users/{id} documents 204 — and, as an upstream defect, even
+    // declares `application/json` on it. A body there is still drift.
+    expect(kindsFor(deleteUser!, observe({ status: 204, body: '{}' }))).toEqual([
+      'undeclared-body',
+    ]);
+  });
+
+  it('accepts an empty body on a status that must not carry one', () => {
+    expect(kindsFor(deleteUser!, observe({ status: 204, contentType: '', body: '' }))).toEqual([]);
+  });
+});

--- a/tests/contract/parity-detects-drift.contract.test.ts
+++ b/tests/contract/parity-detects-drift.contract.test.ts
@@ -31,7 +31,9 @@ import { replayOperation, startMockoon } from './utils/mockoon-harness';
 import {
   findOperation,
   readContract,
+  unsupportedResponseConstructs,
   type ContractOperation,
+  type OpenApiDocument,
   type SchemaObject,
 } from './utils/openapi-contract';
 import {
@@ -165,6 +167,75 @@ describe('a seeded defect in the mock data turns the gate red', () => {
     },
     SEED_TIMEOUT_MS
   );
+});
+
+describe('the unsupported-construct tripwire is precise in both directions', () => {
+  // It guards a BLOCKING gate, so a false positive is as costly as a miss: one
+  // reds CI over a perfectly supported contract, the other quietly validates
+  // less. Property names are chosen by the API author and are never schema
+  // keywords, and `example`/`enum` values are data — but a real sub-schema
+  // nested under a property that happens to be *named* `example` still counts.
+  const mutated = (corrupt: (document: MutableDocument) => void): string[] => {
+    const copy = JSON.parse(JSON.stringify(contract)) as MutableDocument;
+    corrupt(copy);
+    return unsupportedResponseConstructs(copy as unknown as OpenApiDocument);
+  };
+
+  const itemProps = (document: MutableDocument): Record<string, SchemaObject> =>
+    itemProperties(document);
+
+  const mediaType = (document: MutableDocument): Record<string, unknown> =>
+    (
+      document.paths['/api/users']!.get!.responses['200'] as {
+        content: Record<string, Record<string, unknown>>;
+      }
+    ).content['application/json']!;
+
+  it('is silent on the committed contract', () => {
+    expect(unsupportedResponseConstructs(contract)).toEqual([]);
+  });
+
+  it('does not flag a property whose NAME is a schema keyword', () => {
+    expect(
+      mutated(document => Object.assign(itemProps(document), { allOf: { type: 'string' } }))
+    ).toEqual([]);
+  });
+
+  it('does not flag example or enum data that contains schema-like keys', () => {
+    expect(
+      mutated(document => Object.assign(mediaType(document), { example: [{ allOf: 'x' }] }))
+    ).toEqual([]);
+    expect(
+      mutated(document => Object.assign(itemProps(document).email!, { enum: [{ oneOf: 'x' }] }))
+    ).toEqual([]);
+  });
+
+  it('flags a real sub-schema nested under a property named `example`', () => {
+    expect(
+      mutated(document =>
+        Object.assign(itemProps(document), { example: { oneOf: [{ type: 'string' }] } })
+      )
+    ).toHaveLength(1);
+  });
+
+  it('flags a composed schema, a nested composition and a media-type $ref', () => {
+    expect(
+      mutated(document =>
+        Object.assign(mediaType(document), { schema: { allOf: [{ type: 'object' }] } })
+      )
+    ).toHaveLength(1);
+    expect(
+      mutated(document =>
+        Object.assign(itemProps(document), { email: { oneOf: [{ type: 'string' }] } })
+      )
+    ).toHaveLength(1);
+    expect(
+      mutated(document => {
+        const { responses } = document.paths['/api/users']!.get!;
+        responses['200'] = { content: { 'application/json': { $ref: '#/components/x' } } };
+      })
+    ).toHaveLength(1);
+  });
 });
 
 describe('the rules Mockoon cannot be made to produce', () => {

--- a/tests/contract/parity-detects-drift.contract.test.ts
+++ b/tests/contract/parity-detects-drift.contract.test.ts
@@ -45,13 +45,18 @@ const SEED_TIMEOUT_MS = 30_000;
 const ajv = new Ajv2020({ strict: false, allErrors: true });
 const contract = readContract();
 
-const listUsers = findOperation(contract, 'get', '/api/users');
-if (listUsers === undefined) {
-  throw new Error(
-    'GET /api/users is missing from the contract — the seeded-defect cases assume it'
-  );
+/** Fails with the operation's name rather than an opaque destructuring TypeError. */
+function requireOperation(method: 'get' | 'delete', routePath: string): ContractOperation {
+  const found = findOperation(contract, method, routePath);
+  if (found === undefined) {
+    const label = `${method.toUpperCase()} ${routePath}`;
+    throw new Error(`${label} is missing from the contract — the seeded-defect cases assume it`);
+  }
+  return found;
 }
-const LIST_USERS: ContractOperation = listUsers;
+
+const LIST_USERS = requireOperation('get', '/api/users');
+const DELETE_USER = requireOperation('delete', '/api/users/{id}');
 
 let workDir: string;
 
@@ -163,8 +168,6 @@ describe('a seeded defect in the mock data turns the gate red', () => {
 });
 
 describe('the rules Mockoon cannot be made to produce', () => {
-  const deleteUser = findOperation(contract, 'delete', '/api/users/{id}');
-
   const observe = (overrides: Partial<ObservedResponse>): ObservedResponse => ({
     status: 200,
     contentType: 'application/json',
@@ -200,12 +203,12 @@ describe('the rules Mockoon cannot be made to produce', () => {
   it('rejects a body on a status that must not carry one', () => {
     // DELETE /api/users/{id} documents 204 — and, as an upstream defect, even
     // declares `application/json` on it. A body there is still drift.
-    expect(kindsFor(deleteUser!, observe({ status: 204, body: '{}' }))).toEqual([
+    expect(kindsFor(DELETE_USER, observe({ status: 204, body: '{}' }))).toEqual([
       'undeclared-body',
     ]);
   });
 
   it('accepts an empty body on a status that must not carry one', () => {
-    expect(kindsFor(deleteUser!, observe({ status: 204, contentType: '', body: '' }))).toEqual([]);
+    expect(kindsFor(DELETE_USER, observe({ status: 204, contentType: '', body: '' }))).toEqual([]);
   });
 });

--- a/tests/contract/utils/mockoon-harness.ts
+++ b/tests/contract/utils/mockoon-harness.ts
@@ -111,16 +111,30 @@ export async function startMockoon(dataFilePath: string): Promise<MockoonHandle>
         // on the way down, and Jest has no `forceExit` here — a hung teardown
         // costs the whole job's timeout rather than one clear failure.
         stop: () =>
-          new Promise<void>(resolve => {
+          new Promise<void>((resolve, reject) => {
             let deadline: NodeJS.Timeout | undefined;
-            const settle = (): void => {
+            const clear = (): void => {
               if (deadline !== undefined) clearTimeout(deadline);
-              resolve();
             };
-            deadline = setTimeout(settle, STOP_TIMEOUT_MS);
+            // Timing out REJECTS rather than resolving. A wedged server still
+            // holds its port, so resolving would report a clean teardown while
+            // leaking a listener — the failure would resurface later as an
+            // unrelated bind error. Failing here names it where it happened.
+            deadline = setTimeout(() => {
+              reject(new Error(`Mockoon did not stop within ${STOP_TIMEOUT_MS}ms on port ${port}`));
+            }, STOP_TIMEOUT_MS);
             deadline.unref();
-            server.once('stopped', settle);
-            server.once('error', settle);
+            server.once('stopped', () => {
+              clear();
+              resolve();
+            });
+            // An error on the way down still means the listener is gone; the
+            // point of catching it is that waiting for `stopped` alone would
+            // hang forever.
+            server.once('error', () => {
+              clear();
+              resolve();
+            });
             server.stop();
           }),
       };

--- a/tests/contract/utils/mockoon-harness.ts
+++ b/tests/contract/utils/mockoon-harness.ts
@@ -1,0 +1,118 @@
+/**
+ * Boots the mock side of the parity pair, in-process.
+ *
+ * `Mockoon.Dockerfile` runs `mockoon-cli start --data <openapi.json>`. The CLI
+ * is a thin oclif wrapper over `@mockoon/commons-server`: it calls the same
+ * `OpenAPIConverter` to turn the OpenAPI document into a Mockoon environment
+ * and the same `MockoonServer` to serve it. Driving those two classes directly
+ * runs the identical conversion and serving code without Docker, so the parity
+ * gate needs nothing beyond `bun install` — while
+ * `mockoon-pin-parity.contract.test.ts` keeps the library version locked to the
+ * CLI version the image installs, so "identical" stays true.
+ *
+ * Mockoon generates response bodies from the *schema*, not the `example` —
+ * strings come back empty and booleans are randomised on every boot. That is
+ * why the parity rules assert shape, never values.
+ */
+import { createServer } from 'node:net';
+import type { AddressInfo } from 'node:net';
+
+import { MockoonServer, OpenAPIConverter } from '@mockoon/commons-server';
+
+import {
+  exampleRequestBody,
+  type ContractOperation,
+  type OperationObject,
+} from './openapi-contract';
+import type { ObservedResponse } from './response-parity';
+
+/** Path parameter stand-in. Mockoon routes on the path *pattern*, so the value is arbitrary. */
+export const SAMPLE_PATH_PARAM = '018dd6ba-e901-7a8c-b27d-65d122caca6b';
+
+/**
+ * Mockoon fills schema-generated fields through faker, so `confirmed` and
+ * `expires_in` differ between two consecutive requests. Seeding makes a failure
+ * reproducible from the CI log. It does not weaken the gate: every rule here
+ * asserts shape, never a value.
+ */
+const FAKER_SEED = 350;
+
+export interface MockoonHandle {
+  readonly baseUrl: string;
+  stop(): Promise<void>;
+}
+
+/** Asks the OS for an unused port so parallel Jest workers never collide. */
+async function reservePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address() as AddressInfo;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+/** Converts an OpenAPI document into a Mockoon environment and serves it on a free port. */
+export async function startMockoon(dataFilePath: string): Promise<MockoonHandle> {
+  const port = await reservePort();
+  const environment = await new OpenAPIConverter().convertFromOpenAPI(dataFilePath, port);
+
+  if (environment === null) {
+    throw new Error(`Mockoon could not convert ${dataFilePath} into an environment`);
+  }
+
+  const server = new MockoonServer(environment, { fakerOptions: { seed: FAKER_SEED } });
+  // MockoonServer is an EventEmitter: without an `error` listener Node rethrows
+  // every recoverable server error (a malformed request body, for one) as an
+  // unhandled 'error' event and tears down the Jest worker.
+  server.on('error', () => {});
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('started', resolve);
+    server.once('error', (_code, originalError) =>
+      reject(originalError ?? new Error(`Mockoon failed to start on port ${port}`))
+    );
+    server.start();
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    stop: () =>
+      new Promise<void>(resolve => {
+        server.once('stopped', resolve);
+        server.stop();
+      }),
+  };
+}
+
+function requestInit(operation: OperationObject, method: string): RequestInit {
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  const example = exampleRequestBody(operation);
+
+  if (example === undefined) {
+    return { method, headers, redirect: 'manual' };
+  }
+
+  headers['Content-Type'] = example.contentType;
+  return { method, headers, body: example.body, redirect: 'manual' };
+}
+
+/**
+ * Replays one contract operation against the running mock and captures the
+ * response. `redirect: 'manual'` keeps a 302 observable instead of following it.
+ */
+export async function replayOperation(
+  baseUrl: string,
+  { method, path, operation }: ContractOperation
+): Promise<ObservedResponse> {
+  const url = `${baseUrl}${path.replace(/\{[^}]+\}/g, SAMPLE_PATH_PARAM)}`;
+  const response = await fetch(url, requestInit(operation, method.toUpperCase()));
+
+  return {
+    status: response.status,
+    contentType: (response.headers.get('content-type') ?? '').split(';')[0]?.trim() ?? '',
+    body: await response.text(),
+  };
+}

--- a/tests/contract/utils/mockoon-harness.ts
+++ b/tests/contract/utils/mockoon-harness.ts
@@ -42,21 +42,29 @@ export interface MockoonHandle {
   stop(): Promise<void>;
 }
 
-/** Asks the OS for an unused port so parallel Jest workers never collide. */
+/** How many times to re-draw a port before giving up. */
+const PORT_ATTEMPTS = 5;
+
+/**
+ * Asks the OS for an unused port so parallel Jest workers never collide.
+ *
+ * Binds the **wildcard** address, not `127.0.0.1`: MockoonServer binds the
+ * wildcard too, and a loopback-only probe proves nothing about it — a port free
+ * on `127.0.0.1` can still be taken on `::1` or another interface, and the real
+ * bind then fails.
+ */
 async function reservePort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const probe = createServer();
     probe.once('error', reject);
-    probe.listen(0, '127.0.0.1', () => {
+    probe.listen(0, () => {
       const { port } = probe.address() as AddressInfo;
       probe.close(() => resolve(port));
     });
   });
 }
 
-/** Converts an OpenAPI document into a Mockoon environment and serves it on a free port. */
-export async function startMockoon(dataFilePath: string): Promise<MockoonHandle> {
-  const port = await reservePort();
+async function listen(dataFilePath: string, port: number): Promise<MockoonServer> {
   const environment = await new OpenAPIConverter().convertFromOpenAPI(dataFilePath, port);
 
   if (environment === null) {
@@ -66,25 +74,49 @@ export async function startMockoon(dataFilePath: string): Promise<MockoonHandle>
   const server = new MockoonServer(environment, { fakerOptions: { seed: FAKER_SEED } });
   // MockoonServer is an EventEmitter: without an `error` listener Node rethrows
   // every recoverable server error (a malformed request body, for one) as an
-  // unhandled 'error' event and tears down the Jest worker.
+  // unhandled 'error' event and tears down the Jest worker. It is also how a
+  // failed bind surfaces — as an event, never a thrown exception, so the boot
+  // promise below must settle on it or it would hang until the Jest timeout.
   server.on('error', () => {});
 
   await new Promise<void>((resolve, reject) => {
     server.once('started', resolve);
-    server.once('error', (_code, originalError) =>
-      reject(originalError ?? new Error(`Mockoon failed to start on port ${port}`))
+    server.once('error', (code, originalError) =>
+      reject(originalError ?? new Error(`Mockoon failed to start on port ${port} (${code})`))
     );
     server.start();
   });
 
-  return {
-    baseUrl: `http://127.0.0.1:${port}`,
-    stop: () =>
-      new Promise<void>(resolve => {
-        server.once('stopped', resolve);
-        server.stop();
-      }),
-  };
+  return server;
+}
+
+/** Converts an OpenAPI document into a Mockoon environment and serves it on a free port. */
+export async function startMockoon(dataFilePath: string): Promise<MockoonHandle> {
+  let lastError: unknown;
+
+  // Reserving a port and binding it are two steps, so another process can take
+  // it in between. Re-draw rather than fail: parallel Jest workers each boot
+  // their own server, and a flaky gate is a gate people learn to ignore.
+  for (let attempt = 0; attempt < PORT_ATTEMPTS; attempt += 1) {
+    const port = await reservePort();
+    try {
+      const server = await listen(dataFilePath, port);
+      return {
+        baseUrl: `http://127.0.0.1:${port}`,
+        stop: () =>
+          new Promise<void>(resolve => {
+            server.once('stopped', resolve);
+            server.stop();
+          }),
+      };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw new Error(
+    `Mockoon could not bind a free port in ${PORT_ATTEMPTS} attempts: ${String(lastError)}`
+  );
 }
 
 function requestInit(operation: OperationObject, method: string): RequestInit {

--- a/tests/contract/utils/mockoon-harness.ts
+++ b/tests/contract/utils/mockoon-harness.ts
@@ -45,6 +45,9 @@ export interface MockoonHandle {
 /** How many times to re-draw a port before giving up. */
 const PORT_ATTEMPTS = 5;
 
+/** Upper bound on teardown, so a server that never emits `stopped` cannot hang the run. */
+const STOP_TIMEOUT_MS = 5_000;
+
 /**
  * Asks the OS for an unused port so parallel Jest workers never collide.
  *
@@ -103,9 +106,21 @@ export async function startMockoon(dataFilePath: string): Promise<MockoonHandle>
       const server = await listen(dataFilePath, port);
       return {
         baseUrl: `http://127.0.0.1:${port}`,
+        // Settles on `error` and on a deadline as well as on `stopped`: waiting
+        // for `stopped` alone would hang `afterAll` forever if the server errors
+        // on the way down, and Jest has no `forceExit` here — a hung teardown
+        // costs the whole job's timeout rather than one clear failure.
         stop: () =>
           new Promise<void>(resolve => {
-            server.once('stopped', resolve);
+            let deadline: NodeJS.Timeout | undefined;
+            const settle = (): void => {
+              if (deadline !== undefined) clearTimeout(deadline);
+              resolve();
+            };
+            deadline = setTimeout(settle, STOP_TIMEOUT_MS);
+            deadline.unref();
+            server.once('stopped', settle);
+            server.once('error', settle);
             server.stop();
           }),
       };

--- a/tests/contract/utils/openapi-contract.ts
+++ b/tests/contract/utils/openapi-contract.ts
@@ -9,15 +9,18 @@
  *
  * Only the slice the parity gate needs is typed. The document is OpenAPI 3.1
  * with inline response schemas and no `$ref` indirection, so no resolver is
- * required — see the `no-$ref` assertion in the parity spec, which fails if
- * that ever stops being true.
+ * required — `unsupportedResponseConstructs` below, asserted empty by the parity
+ * spec, fails loudly if that ever stops being true.
  */
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 export const CONTRACT_PATH: string = path.join('contracts', 'user-service', 'openapi.json');
 
-/** The HTTP methods a path item may declare. Everything else (`summary`, `parameters`, …) is not an operation. */
+/**
+ * The HTTP methods a path item may declare. Everything else it can hold
+ * (`summary`, `description`, `parameters`, …) is not an operation.
+ */
 export const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
 
 export type HttpMethod = (typeof HTTP_METHODS)[number];
@@ -117,7 +120,10 @@ export const UNSUPPORTED_SCHEMA_KEYWORDS = [
   'additionalProperties',
 ] as const;
 
-/** Every `<location> -> <keyword>` in the document's response schemas that the parity rules cannot handle. */
+/**
+ * Every `<location> -> <keyword>` in the document's response schemas that the
+ * parity rules cannot handle.
+ */
 export function unsupportedResponseConstructs(document: OpenApiDocument): string[] {
   const found: string[] = [];
 
@@ -142,7 +148,10 @@ export function unsupportedResponseConstructs(document: OpenApiDocument): string
   return found;
 }
 
-/** Looks up a single operation by method and path, or `undefined` when the contract does not document it. */
+/**
+ * Looks up a single operation by method and path, or `undefined` when the
+ * contract does not document it.
+ */
 export function findOperation(
   document: OpenApiDocument,
   method: HttpMethod,
@@ -153,7 +162,10 @@ export function findOperation(
   );
 }
 
-/** The response body schema an operation declares for one status and media type, if it declares one. */
+/**
+ * The response body schema an operation declares for one status and media
+ * type, if it declares one.
+ */
 export function responseSchema(
   operation: OperationObject,
   status: string,

--- a/tests/contract/utils/openapi-contract.ts
+++ b/tests/contract/utils/openapi-contract.ts
@@ -1,0 +1,134 @@
+/**
+ * A minimal, read-only view of the committed user-service OpenAPI document.
+ *
+ * `contracts/user-service/openapi.json` plays two roles at once: it is the
+ * pinned upstream contract (fetched by `make update-contracts`, drift-gated by
+ * `make lint-contracts`) **and** the data file `Mockoon.Dockerfile` copies into
+ * the mock the e2e suite runs against. This module reads it as the *contract*
+ * side of that pair; `mockoon-harness.ts` boots the *mock* side.
+ *
+ * Only the slice the parity gate needs is typed. The document is OpenAPI 3.1
+ * with inline response schemas and no `$ref` indirection, so no resolver is
+ * required — see the `no-$ref` assertion in the parity spec, which fails if
+ * that ever stops being true.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export const CONTRACT_PATH: string = path.join('contracts', 'user-service', 'openapi.json');
+
+/** The HTTP methods a path item may declare. Everything else (`summary`, `parameters`, …) is not an operation. */
+export const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+export type HttpMethod = (typeof HTTP_METHODS)[number];
+
+/**
+ * A JSON Schema as it appears inside an OpenAPI media type. Indexed by an open
+ * `unknown` signature because OpenAPI documents legitimately carry annotation
+ * keywords (`example`, `deprecated`, `xml`) that are not JSON Schema.
+ */
+export interface SchemaObject {
+  readonly type?: string | readonly string[];
+  readonly properties?: Readonly<Record<string, SchemaObject>>;
+  readonly items?: SchemaObject;
+  readonly required?: readonly string[];
+  readonly [keyword: string]: unknown;
+}
+
+export interface MediaTypeObject {
+  readonly schema?: SchemaObject;
+  readonly example?: unknown;
+}
+
+export interface ResponseObject {
+  readonly description?: string;
+  readonly content?: Readonly<Record<string, MediaTypeObject>>;
+}
+
+export interface RequestBodyObject {
+  readonly required?: boolean;
+  readonly content?: Readonly<Record<string, MediaTypeObject>>;
+}
+
+export interface OperationObject {
+  readonly operationId?: string;
+  readonly requestBody?: RequestBodyObject;
+  readonly responses?: Readonly<Record<string, ResponseObject>>;
+}
+
+export interface OpenApiDocument {
+  readonly openapi: string;
+  readonly paths: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
+}
+
+/** One replayable operation, flattened out of the nested `paths` structure. */
+export interface ContractOperation {
+  readonly method: HttpMethod;
+  readonly path: string;
+  /** `GET /api/users` — the label every parity failure is reported against. */
+  readonly label: string;
+  readonly operation: OperationObject;
+}
+
+const isHttpMethod = (value: string): value is HttpMethod =>
+  (HTTP_METHODS as readonly string[]).includes(value);
+
+export function readContract(filePath: string = CONTRACT_PATH): OpenApiDocument {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as OpenApiDocument;
+}
+
+/** Flattens `paths` into one entry per HTTP operation, in document order. */
+export function listOperations(document: OpenApiDocument): ContractOperation[] {
+  return Object.entries(document.paths).flatMap(([routePath, pathItem]) =>
+    Object.entries(pathItem)
+      .filter(([key]) => isHttpMethod(key))
+      .map(([method, operation]) => ({
+        method: method as HttpMethod,
+        path: routePath,
+        label: `${method.toUpperCase()} ${routePath}`,
+        operation: operation as OperationObject,
+      }))
+  );
+}
+
+/** Looks up a single operation by method and path, or `undefined` when the contract does not document it. */
+export function findOperation(
+  document: OpenApiDocument,
+  method: HttpMethod,
+  routePath: string
+): ContractOperation | undefined {
+  return listOperations(document).find(
+    entry => entry.method === method && entry.path === routePath
+  );
+}
+
+/** The response body schema an operation declares for one status and media type, if it declares one. */
+export function responseSchema(
+  operation: OperationObject,
+  status: string,
+  mediaType: string = 'application/json'
+): SchemaObject | undefined {
+  return operation.responses?.[status]?.content?.[mediaType]?.schema;
+}
+
+/**
+ * The request body the contract's own example prescribes, if any.
+ *
+ * Mockoon selects a response from method + path alone, so the body never
+ * changes what comes back — sending the contract's example simply keeps the
+ * replayed request a request the contract says is valid, rather than a
+ * synthetic one.
+ */
+export function exampleRequestBody(
+  operation: OperationObject
+): { readonly contentType: string; readonly body: string } | undefined {
+  const content = operation.requestBody?.content;
+  if (!content) return undefined;
+
+  for (const [contentType, mediaType] of Object.entries(content)) {
+    if (mediaType.example !== undefined) {
+      return { contentType, body: JSON.stringify(mediaType.example) };
+    }
+  }
+  return undefined;
+}

--- a/tests/contract/utils/openapi-contract.ts
+++ b/tests/contract/utils/openapi-contract.ts
@@ -91,6 +91,57 @@ export function listOperations(document: OpenApiDocument): ContractOperation[] {
   );
 }
 
+/**
+ * Schema keywords the undeclared-property rule cannot reason about.
+ *
+ * `undeclaredProperties` walks `properties` and `items` only. A schema that
+ * describes its shape through composition instead has neither, so the rule
+ * treats it as free-form and silently stops checking — and ajv does not
+ * backstop it whenever the composition also loses `required`. `$ref` is the
+ * same class of problem one level up: ajv is handed each schema on its own,
+ * with no resolver.
+ *
+ * These are unsupported rather than forbidden. The contract uses none of them
+ * today; the parity spec asserts that stays true, so the day `make
+ * update-contracts` pulls a spec that uses one, the gate fails loudly instead
+ * of quietly validating less.
+ */
+export const UNSUPPORTED_SCHEMA_KEYWORDS = [
+  '$ref',
+  'allOf',
+  'anyOf',
+  'oneOf',
+  'not',
+  'prefixItems',
+  'patternProperties',
+  'additionalProperties',
+] as const;
+
+/** Every `<location> -> <keyword>` in the document's response schemas that the parity rules cannot handle. */
+export function unsupportedResponseConstructs(document: OpenApiDocument): string[] {
+  const found: string[] = [];
+
+  const walk = (node: unknown, trail: string): void => {
+    if (node === null || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      node.forEach((entry, index) => walk(entry, `${trail}[${index}]`));
+      return;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if ((UNSUPPORTED_SCHEMA_KEYWORDS as readonly string[]).includes(key)) {
+        found.push(`${trail}.${key}`);
+      }
+      walk(value, `${trail}.${key}`);
+    }
+  };
+
+  listOperations(document).forEach(({ label, operation }) =>
+    walk(operation.responses ?? {}, `${label} responses`)
+  );
+
+  return found;
+}
+
 /** Looks up a single operation by method and path, or `undefined` when the contract does not document it. */
 export function findOperation(
   document: OpenApiDocument,

--- a/tests/contract/utils/openapi-contract.ts
+++ b/tests/contract/utils/openapi-contract.ts
@@ -121,29 +121,60 @@ export const UNSUPPORTED_SCHEMA_KEYWORDS = [
 ] as const;
 
 /**
+ * Keywords whose values are response *data*, not sub-schemas. The scan must not
+ * descend into them: an example payload with a field literally named `not` or
+ * `allOf` is ordinary data, and flagging it would fail the blocking gate over a
+ * perfectly supported contract.
+ */
+const SCHEMA_DATA_KEYWORDS: ReadonlySet<string> = new Set([
+  'example',
+  'examples',
+  'default',
+  'const',
+  'enum',
+]);
+
+/**
  * Every `<location> -> <keyword>` in the document's response schemas that the
  * parity rules cannot handle.
+ *
+ * Scoped to actual schema positions — it starts at each media type's `schema`
+ * and descends only through schema structure — so it reports what the rules
+ * genuinely cannot reason about and nothing else.
  */
 export function unsupportedResponseConstructs(document: OpenApiDocument): string[] {
   const found: string[] = [];
 
-  const walk = (node: unknown, trail: string): void => {
+  const walkSchema = (node: unknown, trail: string): void => {
     if (node === null || typeof node !== 'object') return;
     if (Array.isArray(node)) {
-      node.forEach((entry, index) => walk(entry, `${trail}[${index}]`));
+      node.forEach((entry, index) => walkSchema(entry, `${trail}[${index}]`));
       return;
     }
-    for (const [key, value] of Object.entries(node)) {
-      if ((UNSUPPORTED_SCHEMA_KEYWORDS as readonly string[]).includes(key)) {
-        found.push(`${trail}.${key}`);
+    for (const [keyword, value] of Object.entries(node)) {
+      if ((UNSUPPORTED_SCHEMA_KEYWORDS as readonly string[]).includes(keyword)) {
+        found.push(`${trail}.${keyword}`);
       }
-      walk(value, `${trail}.${key}`);
+      if (!SCHEMA_DATA_KEYWORDS.has(keyword)) walkSchema(value, `${trail}.${keyword}`);
     }
   };
 
-  listOperations(document).forEach(({ label, operation }) =>
-    walk(operation.responses ?? {}, `${label} responses`)
-  );
+  listOperations(document).forEach(({ label, operation }) => {
+    Object.entries(operation.responses ?? {}).forEach(([status, response]) => {
+      const responseAt = `${label} responses.${status}`;
+      // A `$ref` on the Response or Media Type object itself is unsupported for
+      // the same reason as one inside a schema: nothing here resolves it, and
+      // `responseSchema` would read the media type as schema-less and silently
+      // skip every body rule.
+      if (Object.hasOwn(response, '$ref')) found.push(`${responseAt}.$ref`);
+
+      Object.entries(response.content ?? {}).forEach(([mediaType, media]) => {
+        const mediaAt = `${responseAt}.content.${mediaType}`;
+        if (Object.hasOwn(media, '$ref')) found.push(`${mediaAt}.$ref`);
+        walkSchema(media.schema, `${mediaAt}.schema`);
+      });
+    });
+  });
 
   return found;
 }

--- a/tests/contract/utils/openapi-contract.ts
+++ b/tests/contract/utils/openapi-contract.ts
@@ -135,6 +135,82 @@ const SCHEMA_DATA_KEYWORDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Keywords whose value is a map of *arbitrarily named* sub-schemas. Their keys
+ * are names chosen by the API author, never schema keywords — a response with a
+ * property legitimately called `allOf` must not be mistaken for a composed
+ * schema, and a sub-schema under a property called `example` must still be
+ * scanned.
+ */
+const NAMED_SCHEMA_MAPS: ReadonlySet<string> = new Set([
+  'properties',
+  'patternProperties',
+  '$defs',
+  'definitions',
+]);
+
+const isRecord = (node: unknown): node is Record<string, unknown> =>
+  typeof node === 'object' && node !== null && !Array.isArray(node);
+
+/**
+ * The (sub-schema, location) pairs one keyword's value contributes to the scan.
+ *
+ * Kept separate from the recursion so exactly one function recurses: the
+ * `properties` case in particular must yield each property's *value* while
+ * never letting its *name* reach the keyword checks.
+ */
+function subSchemaTargets(
+  keyword: string,
+  value: unknown,
+  at: string
+): ReadonlyArray<readonly [unknown, string]> {
+  if (NAMED_SCHEMA_MAPS.has(keyword)) {
+    return isRecord(value)
+      ? Object.entries(value).map(([name, subSchema]) => [subSchema, `${at}.${name}`] as const)
+      : [];
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => [entry, `${at}[${index}]`] as const);
+  }
+  return [[value, at] as const];
+}
+
+/** Records every keyword in one schema that the parity rules cannot reason about. */
+function scanSchema(schema: unknown, trail: string, found: string[]): void {
+  if (!isRecord(schema)) return;
+
+  for (const [keyword, value] of Object.entries(schema)) {
+    const at = `${trail}.${keyword}`;
+
+    if ((UNSUPPORTED_SCHEMA_KEYWORDS as readonly string[]).includes(keyword)) {
+      // Nothing below an unsupported keyword adds information: the rules stop
+      // here either way, and the location already names what to fix.
+      found.push(at);
+    } else if (!SCHEMA_DATA_KEYWORDS.has(keyword)) {
+      // Anything else is schema structure. Data keywords are skipped entirely —
+      // descending would flag ordinary payload fields.
+      subSchemaTargets(keyword, value, at).forEach(([node, nodeTrail]) =>
+        scanSchema(node, nodeTrail, found)
+      );
+    }
+  }
+}
+
+/** Records the unsupported constructs in one Response Object's bodies. */
+function scanResponse(response: ResponseObject, trail: string, found: string[]): void {
+  // A `$ref` on the Response or Media Type object itself is unsupported for the
+  // same reason as one inside a schema: nothing here resolves it, and
+  // `responseSchema` would read the media type as schema-less and silently skip
+  // every body rule.
+  if (Object.hasOwn(response, '$ref')) found.push(`${trail}.$ref`);
+
+  for (const [mediaType, media] of Object.entries(response.content ?? {})) {
+    const mediaAt = `${trail}.content.${mediaType}`;
+    if (Object.hasOwn(media, '$ref')) found.push(`${mediaAt}.$ref`);
+    scanSchema(media.schema, `${mediaAt}.schema`, found);
+  }
+}
+
+/**
  * Every `<location> -> <keyword>` in the document's response schemas that the
  * parity rules cannot handle.
  *
@@ -145,34 +221,9 @@ const SCHEMA_DATA_KEYWORDS: ReadonlySet<string> = new Set([
 export function unsupportedResponseConstructs(document: OpenApiDocument): string[] {
   const found: string[] = [];
 
-  const walkSchema = (node: unknown, trail: string): void => {
-    if (node === null || typeof node !== 'object') return;
-    if (Array.isArray(node)) {
-      node.forEach((entry, index) => walkSchema(entry, `${trail}[${index}]`));
-      return;
-    }
-    for (const [keyword, value] of Object.entries(node)) {
-      if ((UNSUPPORTED_SCHEMA_KEYWORDS as readonly string[]).includes(keyword)) {
-        found.push(`${trail}.${keyword}`);
-      }
-      if (!SCHEMA_DATA_KEYWORDS.has(keyword)) walkSchema(value, `${trail}.${keyword}`);
-    }
-  };
-
   listOperations(document).forEach(({ label, operation }) => {
     Object.entries(operation.responses ?? {}).forEach(([status, response]) => {
-      const responseAt = `${label} responses.${status}`;
-      // A `$ref` on the Response or Media Type object itself is unsupported for
-      // the same reason as one inside a schema: nothing here resolves it, and
-      // `responseSchema` would read the media type as schema-less and silently
-      // skip every body rule.
-      if (Object.hasOwn(response, '$ref')) found.push(`${responseAt}.$ref`);
-
-      Object.entries(response.content ?? {}).forEach(([mediaType, media]) => {
-        const mediaAt = `${responseAt}.content.${mediaType}`;
-        if (Object.hasOwn(media, '$ref')) found.push(`${mediaAt}.$ref`);
-        walkSchema(media.schema, `${mediaAt}.schema`);
-      });
+      scanResponse(response, `${label} responses.${status}`, found);
     });
   });
 

--- a/tests/contract/utils/response-parity.ts
+++ b/tests/contract/utils/response-parity.ts
@@ -1,0 +1,177 @@
+/**
+ * The parity rules: does one observed HTTP response match what the contract
+ * documents for the operation that produced it?
+ *
+ * Deliberately pure — it takes an already-captured response, so the same rules
+ * are exercised both against the live mock (`mockoon-openapi-parity`) and
+ * against deliberately corrupted mock data (`parity-detects-drift`). Nothing
+ * here reads the network, the clock, or the filesystem.
+ *
+ * The four rules, in the order they are applied:
+ *
+ *   1. **status**       — the status served must be one the operation documents.
+ *   2. **media type**   — a body must arrive under a media type that status declares.
+ *   3. **schema**       — a body must validate against that media type's schema.
+ *   4. **no extras**    — a body must not carry a property the schema never declares.
+ *
+ * Rule 4 is the load-bearing one for mock drift and is *stricter* than OpenAPI's
+ * default (`additionalProperties` is permissive unless stated). That is
+ * deliberate: a mock offering a field the contract does not describe is exactly
+ * the "e2e certifies behavior the real API does not have" defect this gate
+ * exists to catch. It is also the only rule that catches a renamed field in
+ * this contract, because the upstream document misplaces `required` on the
+ * array schema of `GET /api/users` instead of on its `items` — so ajv alone
+ * accepts a response with every property renamed.
+ */
+import type { ValidateFunction } from 'ajv';
+import type Ajv from 'ajv/dist/2020';
+
+import type { ContractOperation, MediaTypeObject, SchemaObject } from './openapi-contract';
+
+export type ParityProblemKind =
+  | 'undocumented-status'
+  | 'undeclared-body'
+  | 'undocumented-media-type'
+  | 'malformed-body'
+  | 'schema-violation'
+  | 'undeclared-property';
+
+export interface ParityProblem {
+  readonly kind: ParityProblemKind;
+  readonly detail: string;
+}
+
+export interface ObservedResponse {
+  readonly status: number;
+  /** Media type with parameters stripped (`application/json`, not `…; charset=utf-8`). Empty when the response carried no `Content-Type`. */
+  readonly contentType: string;
+  /** Raw response text, exactly as served. */
+  readonly body: string;
+}
+
+/**
+ * Statuses RFC 9110 forbids a body on. An empty body is correct for these no
+ * matter what the document declares — this contract declares
+ * `application/json` on `DELETE /api/users/{id}` 204, which is an upstream
+ * defect that spectral already sees and which must not be reported here as
+ * mock drift.
+ */
+const BODYLESS_STATUSES: ReadonlySet<number> = new Set([204, 304]);
+
+const problem = (kind: ParityProblemKind, detail: string): ParityProblem => ({ kind, detail });
+
+/**
+ * Property paths present in `value` that `schema` never declares.
+ *
+ * Recurses only where the schema describes the shape (`properties`, `items`);
+ * a schema with no `properties` describes a free-form object and is skipped.
+ */
+export function undeclaredProperties(
+  schema: SchemaObject | undefined,
+  value: unknown,
+  trail: string = ''
+): string[] {
+  if (!schema || value === null || typeof value !== 'object') return [];
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) =>
+      undeclaredProperties(schema.items, entry, `${trail}[${index}]`)
+    );
+  }
+
+  const { properties } = schema;
+  if (!properties) return [];
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  return entries.flatMap(([key, nested]) => {
+    const declared = properties[key];
+    const at = `${trail}.${key}`;
+    return declared === undefined ? [at] : undeclaredProperties(declared, nested, at);
+  });
+}
+
+function checkBody(
+  mediaType: MediaTypeObject,
+  observed: ObservedResponse,
+  ajv: Ajv
+): ParityProblem[] {
+  const { schema } = mediaType;
+  // No schema means the contract prescribes only an example (several responses
+  // in this document do, with `example: ""`). There is nothing to validate.
+  if (!schema) return [];
+
+  if (observed.body.length === 0) {
+    return [problem('schema-violation', `empty body where the contract declares a schema`)];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(observed.body);
+  } catch {
+    return [problem('malformed-body', `body is not parseable as ${observed.contentType}`)];
+  }
+
+  const validate: ValidateFunction = ajv.compile(schema);
+  if (!validate(parsed)) {
+    return [problem('schema-violation', ajv.errorsText(validate.errors))];
+  }
+
+  return undeclaredProperties(schema, parsed).map(at =>
+    problem('undeclared-property', `response carries \`${at}\`, which the contract never declares`)
+  );
+}
+
+/** Applies every parity rule to one observed response. An empty array means parity holds. */
+export function checkResponseParity(
+  { operation }: ContractOperation,
+  observed: ObservedResponse,
+  ajv: Ajv
+): ParityProblem[] {
+  const documented = operation.responses ?? {};
+  const status = String(observed.status);
+  const declared = documented[status];
+
+  if (declared === undefined) {
+    const known = Object.keys(documented).join(', ') || 'none';
+    return [problem('undocumented-status', `served ${status}; contract documents ${known}`)];
+  }
+
+  // A bodyless status is satisfied by an empty body regardless of what the
+  // document declares; anything else served under one is real drift.
+  if (BODYLESS_STATUSES.has(observed.status)) {
+    return observed.body.length === 0
+      ? []
+      : [
+          problem(
+            'undeclared-body',
+            `${status} must not carry a body, got ${observed.body.length}B`
+          ),
+        ];
+  }
+
+  const content = declared.content ?? {};
+  const declaredMediaTypes = Object.keys(content);
+
+  if (declaredMediaTypes.length === 0) {
+    return observed.body.length === 0
+      ? []
+      : [problem('undeclared-body', `${status} declares no content, got ${observed.body.length}B`)];
+  }
+
+  const mediaType = content[observed.contentType];
+  if (mediaType === undefined) {
+    return [
+      problem(
+        'undocumented-media-type',
+        `served \`${observed.contentType || 'no Content-Type'}\`; contract declares ${declaredMediaTypes.join(', ')}`
+      ),
+    ];
+  }
+
+  return checkBody(mediaType, observed, ajv);
+}
+
+/** Renders problems for a Jest failure message, one per line. */
+export function formatProblems(label: string, problems: readonly ParityProblem[]): string {
+  return problems.map(({ kind, detail }) => `${label}: [${kind}] ${detail}`).join('\n');
+}

--- a/tests/contract/utils/response-parity.ts
+++ b/tests/contract/utils/response-parity.ts
@@ -43,7 +43,10 @@ export interface ParityProblem {
 
 export interface ObservedResponse {
   readonly status: number;
-  /** Media type with parameters stripped (`application/json`, not `…; charset=utf-8`). Empty when the response carried no `Content-Type`. */
+  /**
+   * Media type with parameters stripped (`application/json`, not
+   * `…; charset=utf-8`). Empty when the response carried no `Content-Type`.
+   */
   readonly contentType: string;
   /** Raw response text, exactly as served. */
   readonly body: string;
@@ -171,7 +174,8 @@ export function checkResponseParity(
     return [
       problem(
         'undocumented-media-type',
-        `served \`${observed.contentType || 'no Content-Type'}\`; contract declares ${declaredMediaTypes.join(', ')}`
+        `served \`${observed.contentType || 'no Content-Type'}\`; ` +
+          `contract declares ${declaredMediaTypes.join(', ')}`
       ),
     ];
   }

--- a/tests/contract/utils/response-parity.ts
+++ b/tests/contract/utils/response-parity.ts
@@ -84,9 +84,12 @@ export function undeclaredProperties(
 
   const entries = Object.entries(value as Record<string, unknown>);
   return entries.flatMap(([key, nested]) => {
-    const declared = properties[key];
     const at = `${trail}.${key}`;
-    return declared === undefined ? [at] : undeclaredProperties(declared, nested, at);
+    // `Object.hasOwn`, not `properties[key] !== undefined`: a response field
+    // named `constructor`, `toString` or `valueOf` would otherwise resolve to
+    // an Object.prototype member and be waved through as "declared".
+    if (!Object.hasOwn(properties, key)) return [at];
+    return undeclaredProperties(properties[key], nested, at);
   });
 }
 
@@ -129,7 +132,10 @@ export function checkResponseParity(
 ): ParityProblem[] {
   const documented = operation.responses ?? {};
   const status = String(observed.status);
-  const declared = documented[status];
+  // `Object.hasOwn` guards every lookup here for the reason spelled out in
+  // `undeclaredProperties`: an inherited Object.prototype member must never
+  // read as something the contract declared.
+  const declared = Object.hasOwn(documented, status) ? documented[status] : undefined;
 
   if (declared === undefined) {
     const known = Object.keys(documented).join(', ') || 'none';
@@ -158,7 +164,9 @@ export function checkResponseParity(
       : [problem('undeclared-body', `${status} declares no content, got ${observed.body.length}B`)];
   }
 
-  const mediaType = content[observed.contentType];
+  const mediaType = Object.hasOwn(content, observed.contentType)
+    ? content[observed.contentType]
+    : undefined;
   if (mediaType === undefined) {
     return [
       problem(


### PR DESCRIPTION
Closes #350.

## The gap

The entire Playwright suite talks to Mockoon, never a real backend, so a green e2e run only
proves the app agrees with **the mock**. Nothing checked that the mock still matched the API's
documented shape — it could rot indefinitely while e2e stayed green, and the mismatch would
surface only in production. Issue #243 / PR #245 (swagger `GET /users` failing in production
mode only) is the recorded instance of exactly that class.

## What landed

Two gates, both anchored on the **single** committed baseline
[`contracts/user-service/openapi.json`](contracts/user-service/openapi.json).

> **Deviation from the issue text, deliberately.** The issue proposes creating
> `config/openapi/spec.baseline.json`. That baseline already exists under a different path:
> `contracts/user-service/openapi.json` is the pinned upstream spec (`USER_SERVICE_VERSION`),
> is drift-gated by `make lint-contracts`, and is literally the file `Mockoon.Dockerfile`
> copies in as its mock data. A second copy would be a guaranteed drift source with nothing
> watching it, so this PR reuses the existing one.

### 1. Blocking — mock-vs-contract parity (`make test-contract`)

New `TEST_ENV=contract` Jest layer under `tests/contract/`. It boots Mockoon **in-process**
through `@mockoon/commons-server` — the libraries the container's `@mockoon/cli` is a thin
wrapper over — replays every documented operation, and asserts four rules per response:

| Rule | Fails when |
| --- | --- |
| `undocumented-status` | the served status is not one the operation documents |
| `undocumented-media-type` / `undeclared-body` | a body arrives under a media type that status does not declare |
| `schema-violation` | the body does not validate against that media type's schema (ajv, 2020-12) |
| `undeclared-property` | the body carries a property the schema never declares |

The last rule is **stricter than OpenAPI's permissive default on purpose**, and it is
load-bearing: the upstream document misplaces `required` on the *array* schema of
`GET /api/users` instead of on its `items`, so ajv alone accepts a response with every
property renamed. Verified — in the seeded rename case ajv reports valid and only the
undeclared-property rule catches it.

Fully hermetic: no Docker, no network, no compose stack. Runs in ~2s on every PR via
`contract-parity-testing.yml`.

Two further legs ride along:

- the swagger e2e fixtures (`src/test/e2e/swagger/utils/constants.ts`) — the hard-coded
  `ApiUser` shape the Playwright specs assert against — are validated against the same
  schema, catching the same drift one layer up;
- `@mockoon/commons` and `@mockoon/commons-server` are pinned **exactly** and asserted equal
  to the `@mockoon/cli` version `Mockoon.Dockerfile` installs, so the gate can never certify
  a Mockoon the e2e stack does not run. Nothing enforced that lock-step before.

### 2. Advisory — upstream drift (`make lint-openapi`, nightly)

A pinned, SHA256-verified `oasdiff` (provisioned exactly like the rust-code-analysis CLI —
`scripts/ci/ensure-oasdiff.sh` mirrors `ensure-rca.sh`) compares the baseline against the
newest `VilnaCRM-Org/user-service` **release**. `openapi-drift.yml` files or refreshes an
`api-contract` tracking issue on breaking drift and closes it when the baseline is current
again — never a red check, because upstream moving on is not a PR author's fault.

Two things worth reviewer attention:

- **"Latest" is resolved from the releases API, not by semver-sorting tags.** Upstream
  restarted its numbering: the highest tag by semver is `v2.8.0` (Aug 2025) while the newest
  release is `v0.8.0` (Feb 2026). Semver-sorting would compare against months-old content and
  report "no drift" indefinitely — a silently dead gate.
- **`scripts/ci/openapi-drift.sh` exits three ways on purpose**: `0` clean, `1` breaking
  drift, `2` the check could not run. Without that split a network outage, a moved upstream
  spec path, or `oasdiff` flag misuse (exit 100/102) would be published as a breaking API
  change — or, under `continue-on-error`, silently swallowed. GNU Make discards a recipe's
  own exit status, so the workflow calls the script directly while `make lint-openapi`
  remains the human-facing surface. This split already earned its keep: it caught a
  `--color`/`--format markdown` incompatibility during development and reported it as
  "could not compare", not as drift.

Like `lint-contracts` and `lint-metrics`, `lint-openapi` stays **outside** `make lint` — it
needs the network and a host binary, and the static lane is hermetic by design.

## Acceptance criteria

- [x] **Check exists and runs on PRs touching the Mockoon data, the swagger e2e utils, or the
      baseline** — it runs on *every* PR, which covers those a fortiori. See the path-filter
      note below.
- [x] **Nightly oasdiff upstream-drift leg exists and files an issue on breaking changes**
      (`openapi-drift.yml`, advisory, `api-contract` label, closes itself when clean).
- [x] **PR leg is blocking** — `contract parity testing / mock-contract-parity` fails the
      workflow. Adding it to the `main` required-checks ruleset is a repository **setting**
      that cannot be committed; the check name is documented in CONTRIBUTING.md for a
      maintainer to add.
- [x] **Check has failed on a deliberately seeded defect** — and does so *repeatably*, in
      committed tests. `parity-detects-drift.contract.test.ts` writes corrupted **copies** of
      the mock data (renamed field, retyped field, added field, moved status), boots Mockoon
      on each and asserts the gate turns red; six more cases drive the rules Mockoon cannot be
      made to produce. The seed never touches the committed contract, which `lint-contracts`
      guards.

### On the path filter

The issue asks for the PR trigger to be path-filtered. Neither new workflow is filtered, on
purpose:

1. The gate also depends on `jest.config.ts`, `package.json` / `bun.lock` (the Mockoon pins)
   and its own harness — a filter scoped to the mock data and swagger utils would let a PR
   that breaks the gate merge with the gate never running. This repo has **twice** widened or
   removed a paths filter for that exact reason; `link-check.yml` carries a permanent in-file
   comment about it.
2. A path-filtered **required** check never reports on non-matching PRs, leaving them
   permanently pending, and this repo has no always-report aggregator job to compensate.

Running unconditionally satisfies the criterion's intent (it certainly runs when those files
change) at a cost of ~2s.

## Scope, stated honestly

Mockoon derives its responses from the same document the validator checks against, so this
gate cannot detect "the mock disagrees with the real API" in general. What it catches is
divergence the converter introduces — a schema the generated mock can no longer satisfy
after a pin bump, a Mockoon upgrade that changes generation, a status or media type the mock
stops serving — plus e2e fixtures written against a shape the contract has dropped. Whether
the contract itself is current is the advisory leg's job.

Its reach is bounded in three ways, all deliberate, all documented in the README, and all
guarded so they cannot quietly widen:

- **One response per operation.** Mockoon serves the first response an operation declares and
  honours neither `Accept` nor `Prefer`, so the documented 4xx/5xx shapes are never
  exercised: 12 responses observed out of 43 declared (status, media-type) pairs.
- **Body only, not headers.** Response headers, including the 302 `Location`, are served but
  not asserted.
- **Schema-bearing responses only.** 7 of the 12 reach the schema and undeclared-property
  rules; the rest declare `example: ""` with no schema, or are bodyless 204s. A committed
  floor assertion fails if that 7 ever drops, and a tripwire fails if upstream introduces
  `$ref` or a composed schema (`allOf`/`oneOf`/`prefixItems`/…) that the undeclared-property
  rule cannot walk — so the gate cannot silently shrink toward validating nothing.

## Verification

```text
CI=1 make lint            # ESLint + tsc + markdownlint + dependency-cruiser — clean
CI=1 make test-contract   # 3 suites, 29 tests — pass (~2s)
CI=1 make test-integration# 49 suites, 240 tests — pass (100% coverage gate intact)
CI=1 make test-unit-client# 76 suites, 399 tests — pass
CI=1 make test-unit-server# 1 suite, 8 tests — pass
CI=1 make test-unit-edge  # 1 suite, 24 tests — pass
make test-bats            # 91 tests — pass (up from 87; 4 new)
make lint-openapi         # exercised end to end against the live upstream
```

`make lint-openapi` currently reports **52 breaking changes** against `v0.8.0` — real,
year-old accumulated upstream drift. That is the gate working, and precisely why this leg is
advisory. The first nightly run will file one tracking issue describing it.

## Notes for review

- `jest.config.ts` gains a fifth `TEST_ENV`. Per the repo's locked-configuration policy: the
  change is additive, mirrors how #349 added the `edge` layer, and is isolated to this PR.
  The layer is deliberately **not** folded into `integration`, whose charter is a global 100%
  coverage sweep over `src/` that a spec about an HTTP mock's wire format contributes nothing
  to; a separate layer also gives the blocking check its own name for the ruleset.
- `eslint.config.mjs` widens two `tests/integration/**` globs to `tests/**` so the new
  directory keeps the same tests-scoped parser options. `tests/` contains no other `.ts`,
  `.tsx` or `.js` files, so this is behaviour-neutral for existing files.
- `@mockoon/commons` + `@mockoon/commons-server` are new devDependencies (exact pins),
  hence the `bun.lock` churn.
- No gate was lowered, excluded or suppressed anywhere in this change.

## Review round

An adversarial self-review plus the PR bots surfaced 9 real defects, each reproduced before
being fixed and each in the same class: a place the gate could report green while checking
less than it claimed.

- **Composed schemas silently switched off the undeclared-property rule.** Reproduced: an
  `allOf` refactor of `GET /api/users/{id}` 200 dropped three of four fields from the served
  body with the gate fully green. `$ref` already had a loud tripwire; it now covers every
  construct the rules cannot reason about.
- **Prototype-chain keys defeated the same rule** — a field renamed to `constructor` resolved
  to an `Object.prototype` member and read as declared. Every lookup now uses `Object.hasOwn`.
- **The port reservation proved nothing** (probe bound loopback, Mockoon binds the wildcard),
  and a failed bind surfaces as an *event*, so the boot promise would have hung until the
  Jest timeout. Wildcard probe, bounded re-draw, promise settles on the error.
- **`stop()` could hang forever** if the server errored on the way down — with no `forceExit`,
  that costs the whole job's timeout instead of one clear failure.
- **`set -e` beat the drift script's error handler**, aborting with curl's exit code (7) and
  breaking the documented three-way contract for the one case it exists to cover.
- **Issue dedup could hit the wrong thread** (`--search` ORs its terms, so it would have
  matched this gate's own tracking issue), treat `"null"` as a match, silently swallow a
  failed `gh issue list` and file duplicates, or stop finding its issue past the list window.
- **A writable regular file at the report path** passed the `-w` check and then failed the
  redirection with exit 1 — an unavailable check indistinguishable from drift.
- **The swagger-fixture guard was vacuous** — both assertions reached through `.items` while
  only the collection was guarded.
- **`ci-test-contract` was missing from `CI_TEST_TARGETS`**, so `make ci-test` and `make ci`
  did not mirror the PR gate set.

Two documentation claims were also wrong and are corrected: the newest upstream tag is about
five months older than the newest release, not "a year", and the scope caveat overstated
coverage while headers go unasserted and only the first declared response per operation is
observed.
