### PR TITLE
ci(#359): fail closed on e2e flakes and memlab leaks

### DIFF
--- a/.github/workflows/e2e-flake-census.yml
+++ b/.github/workflows/e2e-flake-census.yml
@@ -1,0 +1,93 @@
+name: e2e flake census
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+# A census is a measurement, not a gate: never abort one mid-run for a newer trigger.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  census:
+    # Advisory by design (#359). The blocking legs live in e2e-testing.yml and only cover the
+    # specs a pull request changed; this run repeats the WHOLE suite off the PR path so the
+    # pre-existing flake backlog is measured and tracked instead of silently absorbed by
+    # `retries: 2`. It records what it finds and stays green — a red census would page
+    # somebody nightly for debt that is already known.
+    name: nightly flake census
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache Bun cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-
+
+      - name: Setup Bun and install dependencies
+        run: |
+          npm install -g "$(node -p "require('./package.json').packageManager.split('+')[0]")"
+          bun install --frozen-lockfile
+
+      - name: Repeat the whole e2e suite with retries off
+        continue-on-error: true
+        run: make test-e2e-burnin E2E_BURNIN_REPEATS=3
+
+      - name: Summarise the flakes
+        id: census
+        run: |
+          set -euo pipefail
+          make check-e2e-flakes FLAKE_MODE=census FLAKE_REPORT_DIR=test-results/burn-in \
+            | tee census.md
+          cat census.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: File or refresh the flake-tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Idempotent: also provisioned as repo metadata, but a missing label must not
+          # fail the census.
+          gh label create e2e-flake --color FBCA04 \
+            --description "Nightly e2e flake census findings" 2>/dev/null || true
+          title='e2e flake census'
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          body="$(printf '%s\n\n%s\n' "$(cat census.md)" "Census run: $run_url")"
+          existing="$(gh issue list --label e2e-flake --state open \
+            --search "$title in:title" --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --label e2e-flake --title "$title" --body "$body"
+          fi
+
+      - name: Upload census report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: e2e-flake-census-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            playwright-report/
+            test-results/burn-in/results.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-flake-census.yml
+++ b/.github/workflows/e2e-flake-census.yml
@@ -57,7 +57,8 @@ jobs:
         id: census
         run: |
           set -euo pipefail
-          make check-e2e-flakes FLAKE_MODE=census FLAKE_REPORT_DIR=test-results/burn-in \
+          # -s so make does not echo the recipe into the captured Markdown.
+          make -s check-e2e-flakes FLAKE_MODE=census FLAKE_REPORT_DIR=burn-in-results \
             | tee census.md
           cat census.md >> "$GITHUB_STEP_SUMMARY"
 
@@ -73,8 +74,11 @@ jobs:
           title='e2e flake census'
           run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           body="$(printf '%s\n\n%s\n' "$(cat census.md)" "Census run: $run_url")"
+          # `.[0].number` over an empty array prints the literal string "null", which would
+          # pass the -n test and run `gh issue comment null`, so the tracking issue would
+          # never be created on the first census. `first(...) // empty` yields nothing.
           existing="$(gh issue list --label e2e-flake --state open \
-            --search "$title in:title" --json number --jq '.[0].number')"
+            --search "$title in:title" --json number --jq 'first(.[].number) // empty')"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"
           else
@@ -88,6 +92,6 @@ jobs:
           name: e2e-flake-census-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             playwright-report/
-            test-results/burn-in/results.json
+            burn-in-results/results.json
           retention-days: 14
           if-no-files-found: ignore

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -44,15 +44,17 @@ jobs:
           # The diff runs on its own so a git failure (e.g. an unfetched base) still aborts
           # the job; only grep's "no match" exit code is tolerated.
           changed="$(git diff --name-only --diff-filter=d "$BASE_SHA"...HEAD -- src/test/e2e)"
-          specs="$(printf '%s\n' "$changed" \
-            | grep -E '\.spec\.ts$' | tr '\n' ' ' | sed 's/ *$//')" || true
-          # The list is space-separated downstream, so a path containing whitespace would be
-          # split into two nonexistent paths and its flakes would silently drop to advisory.
-          # Refuse loudly instead of gating nothing; repo convention is kebab-case anyway.
-          if printf '%s\n' "$changed" | grep -qE '[[:space:]]'; then
-            echo "::error::e2e spec paths must not contain whitespace: $changed"
+          spec_lines="$(printf '%s\n' "$changed" | grep -E '\.spec\.ts$')" || true
+          # The list is space-separated downstream, so a spec path containing whitespace would
+          # be split into two nonexistent paths and its flakes would silently drop to advisory.
+          # Refuse loudly instead of gating nothing. Only the filtered spec list is checked:
+          # non-spec files under src/test/e2e never reach the downstream list, so a fixture
+          # with a space in its name must not hard-fail this job and cascade into both legs.
+          if printf '%s\n' "$spec_lines" | grep -qE '[[:space:]]'; then
+            echo "::error::e2e spec paths must not contain whitespace: $spec_lines"
             exit 1
           fi
+          specs="$(printf '%s\n' "$spec_lines" | tr '\n' ' ' | sed 's/ *$//')"
           echo "specs=$specs" >> "$GITHUB_OUTPUT"
           if [ -n "$specs" ]; then
             echo "any=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -12,6 +12,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changed-specs:
+    # The flake legs (#359) only block on specs this pull request touched, so the diff is
+    # resolved once here and shared. Full history is needed for the merge-base diff; the
+    # shard jobs keep their shallow checkout.
+    name: changed e2e specs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      specs: ${{ steps.diff.outputs.specs }}
+      any: ${{ steps.diff.outputs.any }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve the e2e specs this pull request changed
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # --diff-filter=d drops deletions: a spec that no longer exists cannot be burned in.
+          # The suffix is filtered with grep rather than a `**/*.spec.ts` pathspec — git
+          # pathspecs are not globstar-aware, so that pattern silently misses every spec
+          # sitting directly in src/test/e2e (11 of 29 today).
+          # The diff runs on its own so a git failure (e.g. an unfetched base) still aborts
+          # the job; only grep's "no match" exit code is tolerated.
+          changed="$(git diff --name-only --diff-filter=d "$BASE_SHA"...HEAD -- src/test/e2e)"
+          specs="$(printf '%s\n' "$changed" \
+            | grep -E '\.spec\.ts$' | tr '\n' ' ' | sed 's/ *$//')" || true
+          echo "specs=$specs" >> "$GITHUB_OUTPUT"
+          if [ -n "$specs" ]; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+            echo "Changed e2e specs: $specs"
+          else
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            echo "No e2e specs changed; the burn-in leg will be skipped."
+          fi
+
   test:
     # The Playwright config pins workers: 1 in CI (Docker cross-container
     # stability), so the whole suite otherwise runs serially in one job. Instead
@@ -51,5 +94,130 @@ jobs:
         if: always()
         with:
           name: playwright-report-e2e-shard-${{ matrix.shardIndex }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: playwright-report/
+          # test-results/results.json is the machine-readable sibling the flake gate reads;
+          # the HTML report alone cannot distinguish a retry-pass from a clean pass.
+          path: |
+            playwright-report/
+            test-results/results.json
           retention-days: 14
+
+  flake-gate:
+    # `retries: 2` in CI means a spec that fails and then passes is reported green (#359).
+    # This job reads every shard's JSON report and fails when a spec the pull request changed
+    # only passed on a retry; flakes in untouched specs are annotated, not blocked.
+    name: e2e flake gate
+    needs: [test, changed-specs]
+    # Run even when a shard failed so the gate fails CLOSED rather than being skipped —
+    # branch protection treats a skipped required check as passing.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Fail if any e2e shard did not succeed
+        if: needs.test.result != 'success'
+        env:
+          SHARD_RESULT: ${{ needs.test.result }}
+        run: |
+          echo "::error::e2e shards did not all succeed (result=$SHARD_RESULT); failing the gate."
+          exit 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache Bun cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-
+
+      - name: Setup Bun and install dependencies
+        run: |
+          # Install the exact Bun pinned in package.json's packageManager field,
+          # so the version is declared in exactly one place. Corepack does not
+          # manage Bun, so it is installed globally via `npm install -g`.
+          npm install -g "$(node -p "require('./package.json').packageManager.split('+')[0]")"
+          bun install --frozen-lockfile
+
+      - name: Download shard reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: playwright-report-e2e-shard-*
+          path: flake-reports
+
+      - name: Fail on a retry-pass in a changed spec
+        env:
+          CHANGED_SPECS: ${{ needs.changed-specs.outputs.specs }}
+        run: |
+          make check-e2e-flakes FLAKE_MODE=retry-pass FLAKE_REPORT_DIR=flake-reports \
+            FLAKE_CHANGED_SPECS="$CHANGED_SPECS"
+
+  burn-in:
+    # Re-runs only the specs the pull request changed, with retries off, so nondeterminism
+    # shows up as some-but-not-all failures. Skipped entirely when no e2e spec changed.
+    name: burn in changed e2e specs
+    needs: changed-specs
+    if: ${{ needs.changed-specs.outputs.any == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache Bun cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ hashFiles('.nvmrc') }}-
+
+      - name: Setup Bun and install dependencies
+        run: |
+          npm install -g "$(node -p "require('./package.json').packageManager.split('+')[0]")"
+          bun install --frozen-lockfile
+
+      - name: Repeat the changed specs with retries off
+        # A partial failure is the signal, so the run's own exit code is not the verdict —
+        # the verdict step below grades the report and owns the outcome.
+        continue-on-error: true
+        env:
+          CHANGED_SPECS: ${{ needs.changed-specs.outputs.specs }}
+        run: make test-e2e-burnin E2E_BURNIN_SPECS="$CHANGED_SPECS"
+
+      - name: Grade the burn-in
+        env:
+          CHANGED_SPECS: ${{ needs.changed-specs.outputs.specs }}
+        run: |
+          make check-e2e-flakes FLAKE_MODE=burn-in FLAKE_REPORT_DIR=test-results/burn-in \
+            FLAKE_CHANGED_SPECS="$CHANGED_SPECS"
+
+      - name: Upload burn-in report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: playwright-report-e2e-burn-in-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            playwright-report/
+            test-results/burn-in/results.json
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -46,6 +46,13 @@ jobs:
           changed="$(git diff --name-only --diff-filter=d "$BASE_SHA"...HEAD -- src/test/e2e)"
           specs="$(printf '%s\n' "$changed" \
             | grep -E '\.spec\.ts$' | tr '\n' ' ' | sed 's/ *$//')" || true
+          # The list is space-separated downstream, so a path containing whitespace would be
+          # split into two nonexistent paths and its flakes would silently drop to advisory.
+          # Refuse loudly instead of gating nothing; repo convention is kebab-case anyway.
+          if printf '%s\n' "$changed" | grep -qE '[[:space:]]'; then
+            echo "::error::e2e spec paths must not contain whitespace: $changed"
+            exit 1
+          fi
           echo "specs=$specs" >> "$GITHUB_OUTPUT"
           if [ -n "$specs" ]; then
             echo "any=true" >> "$GITHUB_OUTPUT"
@@ -120,12 +127,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Fail if any e2e shard did not succeed
-        if: needs.test.result != 'success'
+      - name: Fail if a dependency did not succeed
+        # Both dependencies must be checked. A failed `changed-specs` yields an empty spec
+        # list, which would send every retry-pass to the advisory set and report success —
+        # one broken diff job would silently disarm the gate.
+        if: needs.test.result != 'success' || needs.changed-specs.result != 'success'
         env:
           SHARD_RESULT: ${{ needs.test.result }}
+          DIFF_RESULT: ${{ needs.changed-specs.result }}
         run: |
-          echo "::error::e2e shards did not all succeed (result=$SHARD_RESULT); failing the gate."
+          echo "::error::e2e prerequisites did not succeed (shards=$SHARD_RESULT," \
+            "changed-specs=$DIFF_RESULT); failing the gate closed."
           exit 1
 
       - name: Set up Node.js
@@ -167,12 +179,24 @@ jobs:
     # shows up as some-but-not-all failures. Skipped entirely when no e2e spec changed.
     name: burn in changed e2e specs
     needs: changed-specs
-    if: ${{ needs.changed-specs.outputs.any == 'true' }}
+    # Skipped only when the diff genuinely resolved to no e2e specs. If `changed-specs`
+    # itself failed the job still runs and fails closed below, because branch protection
+    # counts a skipped required check as passing.
+    if: ${{ !cancelled() && (needs.changed-specs.result != 'success' || needs.changed-specs.outputs.any == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
       contents: read
     steps:
+      - name: Fail if the changed-spec diff did not succeed
+        if: needs.changed-specs.result != 'success'
+        env:
+          DIFF_RESULT: ${{ needs.changed-specs.result }}
+        run: |
+          echo "::error::changed-specs did not succeed (result=$DIFF_RESULT);" \
+            "cannot know what to burn in, so failing closed."
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -208,7 +232,7 @@ jobs:
         env:
           CHANGED_SPECS: ${{ needs.changed-specs.outputs.specs }}
         run: |
-          make check-e2e-flakes FLAKE_MODE=burn-in FLAKE_REPORT_DIR=test-results/burn-in \
+          make check-e2e-flakes FLAKE_MODE=burn-in FLAKE_REPORT_DIR=burn-in-results \
             FLAKE_CHANGED_SPECS="$CHANGED_SPECS"
 
       - name: Upload burn-in report
@@ -218,6 +242,6 @@ jobs:
           name: playwright-report-e2e-burn-in-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             playwright-report/
-            test-results/burn-in/results.json
+            burn-in-results/results.json
           retention-days: 14
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ next-env.d.ts
 storybook-static/
 storybook-static-ci/
 /test-results/
+# Burn-in reports sit outside test-results so the flake grader never sweeps both cohorts
+# into one recursive walk (see E2E_BURNIN_REPORT_DIR in the Makefile).
+/burn-in-results/
 /playwright-report/
 /blob-report/
 /playwright/.cache/

--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -90,6 +90,13 @@ mode = "comment"
 
 [[plugin]]
 name = "eslint"
+# Pinned to the same ESLint the repo runs (see `eslint` in package.json). Left
+# unpinned, newer Qlty CLIs default to their own ESLint 10.x while still
+# installing this repo's eslint-plugin-react 7.x through `package_filters`; that
+# plugin calls `context.getFilename()`, which ESLint 10 removed, so every build
+# dies with "Error while loading rule 'react/display-name'". Keep in step with
+# package.json so Qlty and `make lint-next` stay the same check.
+version = "9.39.4"
 package_file = "package.json"
 package_filters = ["eslint", "jest", "prettier"]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ make test-unit-server   # Apollo server unit tests (TEST_ENV=server, node)
 make test-unit-edge     # Edge-script unit tests (TEST_ENV=edge, node; scripts/, 100% per-file)
 make test-integration   # Integration layer (TEST_ENV=integration)
 make test-e2e           # Playwright E2E (prod stack + Mockoon API mock)
+make test-e2e-burnin    # Repeat E2E_BURNIN_SPECS with retries off to expose flaky specs
+make check-e2e-flakes   # Grade a Playwright JSON report (FLAKE_MODE=retry-pass|burn-in|census)
 make test-visual        # Playwright visual regression
 make test-visual-update # Refresh visual snapshots after a reviewed UI change
 make test-mutation      # Stryker mutation testing
@@ -81,6 +83,24 @@ Unit suites accept `CI=1` to run on the host without Docker (e.g. `CI=1 make
 test-unit-all`). E2E and visual specs run Playwright inside the prod/test compose stack;
 E2E uses Mockoon to mock the API. The test-layer map and coverage policy live in
 [`agents.md`](agents.md).
+
+### Flake and leak gates (issues #359, #354)
+
+Two suites that used to run without asserting anything now fail closed:
+
+- **E2E flakes.** `playwright.config.ts` retries twice in CI, so a spec that passes only on
+  a retry is reported green. The JSON reporter feeds `scripts/ci/flaky-report.ts`; the
+  `e2e flake gate` job fails when a spec **the PR changed** passed on a retry, and the
+  `burn in changed e2e specs` job re-runs those specs with `--repeat-each=5 --retries=0`
+  and fails at two or more failures. Flakes in untouched specs are annotated, not blocked,
+  and the nightly `e2e flake census` tracks them in a labelled issue.
+- **Memory leaks.** `src/test/memory-leak/runMemlabTests.js` reads the leak clusters memlab
+  returns and exits non-zero for any cluster not recorded in
+  `src/test/memory-leak/leak-baseline.json`. Every baseline entry needs a reason, a
+  tracking issue, and a `validUntil` date; the gate fails once that date passes.
+
+Never widen a retry budget, raise a leak allowance, or add an allowance for a leak your
+change introduced — fix the race or the retainer instead.
 
 ### Running a single unit test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,48 @@ full list and the sharded score is identical to an unsharded run — the gate is
 preserved, never relaxed. The merge job runs even when a shard fails, so the
 gate fails closed rather than passing vacuously.
 
+#### E2E flakes are detected, not retried away
+
+`playwright.config.ts` sets `retries: 2` in CI, so a spec that fails and then
+passes is reported green and the flake signal is thrown away. That is how the
+WebKit swagger flake in #290 reached the production CodePipeline. Two jobs in
+`e2e-testing.yml` recover the signal, both scoped to the specs your pull request
+actually changed:
+
+- **`e2e flake gate`** reads every shard's Playwright JSON report
+  (`test-results/results.json`) through
+  [`scripts/ci/flaky-report.ts`](scripts/ci/flaky-report.ts) and fails when a
+  changed spec carries Playwright's `flaky` status — i.e. it only passed on a
+  retry. Like the mutation merge gate, it runs even when a shard failed so it
+  cannot pass vacuously.
+- **`burn in changed e2e specs`** runs `make test-e2e-burnin` on those specs with
+  `--repeat-each=5 --retries=0`. Two or more failures out of five is a flake;
+  a single failure is tolerated so one-off infrastructure blips do not block a
+  pull request.
+
+Flaky specs you did **not** touch are reported as annotations rather than
+failures, so the pre-existing backlog does not block unrelated work; the nightly
+`e2e flake census` workflow repeats the whole suite off the PR path and records
+what it finds in an `e2e-flake`-labelled issue.
+
+If a burn-in goes red, fix the nondeterminism at its source. Adding a
+`waitForTimeout`, widening `retries`, or wrapping the assertion in a condition
+defeats the gate and is not an acceptable fix.
+
+#### Memory leaks fail the job
+
+`make test-memory-leak` used to run memlab and discard its findings, so a run
+that detected fifty leak clusters exited 0 exactly like a clean one. The runner
+now reads the clusters and exits non-zero, printing the retainer traces for the
+scenarios that failed.
+
+Clusters that already existed when the gate was armed are recorded in
+[`src/test/memory-leak/leak-baseline.json`](src/test/memory-leak/leak-baseline.json),
+each with a reason, a tracking issue, and a `validUntil` date — the gate fails
+once that date passes, so accepted debt cannot become permanent. An allowance is
+only ever for debt that predates the gate: if your change introduces a leak, fix
+the retainer.
+
 #### Dockerfile build performance
 
 If your change touches a `Dockerfile` (or the gate's own config), a CI gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,12 @@ once that date passes, so accepted debt cannot become permanent. An allowance is
 only ever for debt that predates the gate: if your change introduces a leak, fix
 the retainer.
 
+Cluster counts differ between environments — `swaggerInteractions` clusters at
+13 on a GitHub-hosted runner and 28–29 locally — so an allowance records the
+maximum seen anywhere. A run below its allowance therefore prints a `ratchet`
+notice rather than failing. Do not act on a single low reading: lowering an
+allowance to a CI-only figure turns every local run red.
+
 #### Dockerfile build performance
 
 If your change touches a `Dockerfile` (or the gate's own config), a CI gate

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ MERGE_MUTATION_REPORTS_CMD  = bun x tsx scripts/ci/merge-mutation-reports.ts
 # blanket `retries: 2` the CI Playwright config sets.
 E2E_BURNIN_SPECS            ?= $(TEST_DIR_E2E)
 E2E_BURNIN_REPEATS          ?= 5
+# The burn-in report deliberately sits OUTSIDE test-results: the grader walks its report
+# directory recursively, so nesting it would make a local `make check-e2e-flakes` parse the
+# shard report and the burn-in report together as one cohort under a single FLAKE_MODE.
+E2E_BURNIN_REPORT_DIR       ?= burn-in-results
 FLAKE_MODE                  ?= retry-pass
 FLAKE_REPORT_DIR            ?= test-results
 FLAKE_CHANGED_SPECS         ?=
@@ -193,8 +197,9 @@ E2E_SHARD_INDEX             ?= 1
 E2E_SHARD_TOTAL             ?= 1
 run-e2e-shard               = $(PLAYWRIGHT_TEST) "$(PLAYWRIGHT_BIN) test $(TEST_DIR_E2E) --shard=$(E2E_SHARD_INDEX)/$(E2E_SHARD_TOTAL)"
 # Burn-in: repeat each spec with retries off so a flake surfaces as a partial failure. The
-# JSON report goes to its own path so it never overwrites the shard run's report.
-run-e2e-burnin              = $(PLAYWRIGHT_TEST) "PLAYWRIGHT_JSON_REPORT=test-results/burn-in/results.json \
+# JSON report goes to its own top-level directory so it neither overwrites the shard run's
+# report nor gets swept up by a recursive walk of test-results.
+run-e2e-burnin              = $(PLAYWRIGHT_TEST) "PLAYWRIGHT_JSON_REPORT=$(E2E_BURNIN_REPORT_DIR)/results.json \
                               $(PLAYWRIGHT_BIN) test $(E2E_BURNIN_SPECS) --repeat-each=$(E2E_BURNIN_REPEATS) --retries=0"
 playwright-test             = $(PLAYWRIGHT_DOCKER_CMD) $(PLAYWRIGHT_BIN) test
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,17 @@ MUTATION_SHARD_TOTAL        ?= 1
 MUTATION_SHARD_INDEX        ?= 0
 MERGE_MUTATION_REPORTS_CMD  = bun x tsx scripts/ci/merge-mutation-reports.ts
 
+# E2E flake detection (#359). The burn-in re-runs the specs a PR changed with retries off, so
+# nondeterminism shows up as some-but-not-all failures instead of being absorbed by the
+# blanket `retries: 2` the CI Playwright config sets.
+E2E_BURNIN_SPECS            ?= $(TEST_DIR_E2E)
+E2E_BURNIN_REPEATS          ?= 5
+FLAKE_MODE                  ?= retry-pass
+FLAKE_REPORT_DIR            ?= test-results
+FLAKE_CHANGED_SPECS         ?=
+FLAKE_THRESHOLD             ?= 2
+CHECK_FLAKY_REPORT_CMD      = bun x tsx scripts/ci/check-flaky-report.ts
+
 SERVE_CMD                   = --collect.startServerCommand="$(SERVE_BIN) -l $(NEXT_PUBLIC_PROD_PORT) out" \
                               --collect.startServerReadyPattern="Accepting connections"
 LHCI                        = bun x lhci autorun
@@ -181,6 +192,10 @@ run-e2e                     = $(PLAYWRIGHT_TEST) "$(PLAYWRIGHT_BIN) test $(TEST_
 E2E_SHARD_INDEX             ?= 1
 E2E_SHARD_TOTAL             ?= 1
 run-e2e-shard               = $(PLAYWRIGHT_TEST) "$(PLAYWRIGHT_BIN) test $(TEST_DIR_E2E) --shard=$(E2E_SHARD_INDEX)/$(E2E_SHARD_TOTAL)"
+# Burn-in: repeat each spec with retries off so a flake surfaces as a partial failure. The
+# JSON report goes to its own path so it never overwrites the shard run's report.
+run-e2e-burnin              = $(PLAYWRIGHT_TEST) "PLAYWRIGHT_JSON_REPORT=test-results/burn-in/results.json \
+                              $(PLAYWRIGHT_BIN) test $(E2E_BURNIN_SPECS) --repeat-each=$(E2E_BURNIN_REPEATS) --retries=0"
 playwright-test             = $(PLAYWRIGHT_DOCKER_CMD) $(PLAYWRIGHT_BIN) test
 
 help:
@@ -373,6 +388,14 @@ test-e2e: start-prod  ## Start production and run E2E tests (Playwright)
 test-e2e-shard: start-prod ## Start production and run one E2E shard (E2E_SHARD_INDEX of E2E_SHARD_TOTAL; used by the e2e workflow matrix)
 	$(run-e2e-shard)
 
+test-e2e-burnin: start-prod ## Re-run E2E_BURNIN_SPECS E2E_BURNIN_REPEATS times with retries off to expose flaky specs (#359)
+	$(run-e2e-burnin)
+
+check-e2e-flakes: ## Grade a Playwright JSON report for flakes, host-only (FLAKE_MODE=retry-pass|burn-in|census, FLAKE_CHANGED_SPECS=<specs>)
+	FLAKE_MODE="$(FLAKE_MODE)" FLAKE_REPORT_DIR="$(FLAKE_REPORT_DIR)" \
+	FLAKE_CHANGED_SPECS="$(FLAKE_CHANGED_SPECS)" FLAKE_THRESHOLD="$(FLAKE_THRESHOLD)" \
+	$(CHECK_FLAKY_REPORT_CMD)
+
 test-e2e-ui: start-prod ## Start the production environment and run E2E tests with the UI available at $(UI_MODE_URL)
 	@echo "🚀 Starting Playwright UI tests..."
 	@echo "Test will be run on: $(UI_MODE_URL)"
@@ -461,7 +484,7 @@ ci-test-integration: ## Run integration tests directly assuming deps are install
 	ci-test-memory-leak ci-test-load ci-test-lighthouse-desktop \
 	ci-test-lighthouse-mobile ci-test-prod ensure-dev start-prod-clean \
 	test-load test-load-swagger test-mutation-shard merge-mutation-reports \
-	pr-comments
+	test-e2e-burnin check-e2e-flakes pr-comments
 
 ci-setup: create-network ## Prepare the shared dev environment for CI-oriented checks
 	$(DOCKER_COMPOSE) $(DOCKER_COMPOSE_DEV_FILE) up $(CI_SETUP_UP_FLAGS) dev && $(MAKE) wait-for-dev
@@ -510,7 +533,7 @@ ci-test-memory-leak: ## Run Memlab memory leak tests against the dedicated compo
 	}; \
 	trap cleanup EXIT; \
 	echo "🧪 Starting memory leak test environment..."; \
-	$(DOCKER_COMPOSE) -p memleak $(DOCKER_COMPOSE_MEMLEAK_FILE) up -d --wait $(MEMLEAK_SERVICE); \
+	$(DOCKER_COMPOSE) -p memleak $(DOCKER_COMPOSE_MEMLEAK_FILE) up -d --wait --build $(MEMLEAK_SERVICE); \
 	echo "🧹 Cleaning up previous memory leak results..."; \
 	$(DOCKER_COMPOSE) -p memleak $(DOCKER_COMPOSE_MEMLEAK_FILE) exec -T $(MEMLEAK_SERVICE) rm -rf $(MEMLEAK_RESULTS_DIR); \
 	echo "🚀 Running memory leak tests..."; \
@@ -553,7 +576,7 @@ test-memory-leak: start-prod ## This command executes memory leaks tests using M
 
 memory-leak-dind: start-prod ## Run Memlab tests in isolated compose project (DIND safe)
 	@echo "🧪 Starting memory leak test environment (isolated project)..."
-	$(DOCKER_COMPOSE) -p memleak $(DOCKER_COMPOSE_MEMLEAK_FILE) up -d --wait $(MEMLEAK_SERVICE)
+	$(DOCKER_COMPOSE) -p memleak $(DOCKER_COMPOSE_MEMLEAK_FILE) up -d --wait --build $(MEMLEAK_SERVICE)
 	@echo "🧹 Cleaning up previous memory leak results..."
 	$(DOCKER_COMPOSE) -p memleak $(DOCKER_COMPOSE_MEMLEAK_FILE) exec -T $(MEMLEAK_SERVICE) rm -rf $(MEMLEAK_RESULTS_DIR)
 	@echo "🚀 Running memory leak tests..."

--- a/README.md
+++ b/README.md
@@ -114,9 +114,11 @@ Testing
   make test-integration: runs the integration layer (real Apollo transport, network stubbed)
   make test-integration-watch: runs the integration layer in watch mode
   make test-bats: runs the Bats shell regression suite for Makefile targets and CI helper scripts
-  make test-memory-leak: runs memory leak tests using Memlab
+  make test-memory-leak: runs memory leak tests using Memlab and fails on unaccounted leak clusters
   make load-tests: executes load tests using the K6 library
   make test-e2e: runs end-to-end tests inside the prod container
+  make test-e2e-burnin: repeats E2E_BURNIN_SPECS with retries off to expose flaky specs
+  make check-e2e-flakes: grades a Playwright JSON report for retry-passes and burn-in flakes
   make test-e2e-ui: runs end-to-end tests with UI inside the prod container
   make test-visual: runs visual tests inside the prod container
   make test-visual-ui: runs visual tests with UI inside the prod container

--- a/agents.md
+++ b/agents.md
@@ -49,6 +49,19 @@ strength), `make test-bats` (Makefile and CI shell flows), `make test-memory-lea
 `make load-tests` (traffic, K6), and `make lighthouse-desktop` / `make lighthouse-mobile`
 (performance, accessibility, best practices).
 
+Two of those suites assert on more than their own exit code, so a change that touches them
+needs a second look (issues #359 and #354):
+
+- **When you change an e2e spec**, CI re-runs it with `make test-e2e-burnin`
+  (`--repeat-each=5 --retries=0`) and fails at two or more failures. A separate gate job
+  fails if that spec passed only on a retry. Both legs are scoped to the specs in the diff.
+  Fix the race — never add a wait, widen `retries`, or make the assertion conditional to
+  get through.
+- **When a change adds a leak**, `make test-memory-leak` fails with the retainer trace.
+  Accepted, pre-existing clusters live in `src/test/memory-leak/leak-baseline.json`, each
+  with a reason, a tracking issue, and a `validUntil` expiry. An allowance is for debt that
+  predates the gate, never for a leak your change introduced.
+
 In CI these suites are fanned out to run in parallel (issue #316): every workflow declares a
 `concurrency` group (PR checks cancel superseded runs; deploy/release/sandbox do not),
 the Playwright e2e suite, Lighthouse, and the K6 load suites run as matrices, and mutation

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,14 @@ export default defineConfig({
   // Omit `workers` off-CI (Playwright's own default) rather than passing an
   // explicit `undefined`, which `exactOptionalPropertyTypes` rejects.
   ...(process.env.CI ? { workers: 1 } : {}),
-  reporter: [['html', { open: 'never' }]],
+  // The HTML report is for humans; the JSON one is what the flake gate (#359) reads. Without
+  // it a retry-pass (`status: 'flaky'`) is indistinguishable from a clean pass, which is how
+  // the WebKit swagger flake in #290 reached the production pipeline. The path is
+  // overridable so the burn-in leg can keep its report separate from the shard run's.
+  reporter: [
+    ['html', { open: 'never' }],
+    ['json', { outputFile: process.env.PLAYWRIGHT_JSON_REPORT ?? 'test-results/results.json' }],
+  ],
   use: {
     trace: 'on-first-retry',
     ignoreHTTPSErrors: true,

--- a/scripts/ci/check-flaky-report.ts
+++ b/scripts/ci/check-flaky-report.ts
@@ -74,11 +74,19 @@ function resolveChangedSpecs(): string[] {
   return (process.env.FLAKE_CHANGED_SPECS ?? '').split(/\s+/).filter(Boolean);
 }
 
-/** Read the burn-in failure threshold (`>= threshold` failures is a flake). */
+/**
+ * Read the burn-in failure threshold (`>= threshold` failures is a flake).
+ *
+ * The whole value is matched before parsing: `Number.parseInt` would read "2.5" and "2oops"
+ * as 2, so a typo'd threshold would silently run the gate at the default instead of failing.
+ */
 function resolveThreshold(): number {
   const raw = process.env.FLAKE_THRESHOLD ?? '2';
-  const threshold = Number.parseInt(raw, 10);
-  if (!Number.isInteger(threshold) || threshold < 1) {
+  if (!/^\d+$/.test(raw.trim())) {
+    throw new Error(`FLAKE_THRESHOLD must be a positive integer; got "${raw}".`);
+  }
+  const threshold = Number.parseInt(raw.trim(), 10);
+  if (threshold < 1) {
     throw new Error(`FLAKE_THRESHOLD must be a positive integer; got "${raw}".`);
   }
   return threshold;
@@ -125,15 +133,34 @@ function gate(mode: Mode, findings: readonly FlakeFinding[], changed: readonly s
   return 0;
 }
 
-/** Print the advisory census as Markdown for the nightly tracking issue. */
+/**
+ * Print the advisory census as Markdown for the nightly tracking issue.
+ *
+ * A test that failed every single repetition is deterministically broken, not
+ * nondeterministic, so it is listed separately — calling it flaky would send whoever reads
+ * the tracking issue hunting for a race that does not exist.
+ */
 function census(findings: readonly FlakeFinding[]): void {
-  if (findings.length === 0) {
+  const flaky = findings.filter(finding => finding.failures < finding.runs);
+  const broken = findings.filter(finding => finding.failures === finding.runs);
+
+  if (flaky.length === 0) {
     process.stdout.write('No flaky tests detected in this census run.\n');
-    return;
+  } else {
+    process.stdout.write(`Detected ${flaky.length} flaky test(s):\n\n`);
+    for (const finding of flaky) {
+      process.stdout.write(`- ${describeFinding(finding)}\n`);
+    }
   }
-  process.stdout.write(`Detected ${findings.length} flaky test(s):\n\n`);
-  for (const finding of findings) {
-    process.stdout.write(`- ${describeFinding(finding)}\n`);
+
+  if (broken.length > 0) {
+    process.stdout.write(
+      `\nAlso ${broken.length} test(s) failed every repetition — consistently broken rather ` +
+        'than flaky:\n\n'
+    );
+    for (const finding of broken) {
+      process.stdout.write(`- ${describeFinding(finding)}\n`);
+    }
   }
 }
 
@@ -143,6 +170,16 @@ function main(): void {
   const files = findReportFiles(dir);
 
   if (files.length === 0) {
+    // The two blocking modes fail closed: a missing report must never pass a gate vacuously.
+    // The census is a measurement rather than a gate, so it reports the gap and stays green
+    // — otherwise a burn-in that times out would page somebody nightly over missing data.
+    if (mode === 'census') {
+      process.stdout.write(
+        `No Playwright ${REPORT_FILE} found under "${dir}", so this census measured nothing. ` +
+          'The burn-in run probably failed or timed out; see the job log.\n'
+      );
+      return;
+    }
     throw new Error(
       `No Playwright ${REPORT_FILE} found under "${dir}". A missing report must not pass ` +
         'the flake gate vacuously — check that the e2e run produced its JSON reporter output.'

--- a/scripts/ci/check-flaky-report.ts
+++ b/scripts/ci/check-flaky-report.ts
@@ -1,0 +1,174 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+import {
+  describeFinding,
+  findBurnInFailures,
+  findRetryPasses,
+  partitionByChanged,
+  type FlakeFinding,
+  type PlaywrightJsonReport,
+} from './flaky-report';
+
+const REPORT_FILE = 'results.json';
+
+/** Recursion cap for the report walk; the artifact layout is two levels deep at most. */
+const MAX_DEPTH = 6;
+
+type Mode = 'retry-pass' | 'burn-in' | 'census';
+
+const MODES: readonly Mode[] = ['retry-pass', 'burn-in', 'census'];
+
+/**
+ * Resolve the report directory from the environment, rejecting anything outside the
+ * repository so the walk can never be pointed at an arbitrary filesystem path.
+ */
+function resolveReportDir(): string {
+  const root = process.cwd();
+  const dir = resolve(root, process.env.FLAKE_REPORT_DIR ?? 'test-results');
+  const rel = relative(root, dir);
+  if (rel.startsWith('..')) {
+    throw new Error(`FLAKE_REPORT_DIR must stay inside the repository; got "${dir}".`);
+  }
+  return dir;
+}
+
+/** Collect every `results.json` under `dir`; each shard artifact contributes one. */
+function findReportFiles(dir: string, depth = 0): string[] {
+  if (depth > MAX_DEPTH) {
+    return [];
+  }
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...findReportFiles(full, depth + 1));
+    } else if (entry === REPORT_FILE) {
+      files.push(full);
+    }
+  }
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+/** Parse every discovered report, failing loudly rather than skipping malformed JSON. */
+function loadReports(files: readonly string[]): PlaywrightJsonReport[] {
+  return files.map(file => {
+    const raw = readFileSync(file, 'utf8');
+    try {
+      return JSON.parse(raw) as PlaywrightJsonReport;
+    } catch (error) {
+      throw new Error(`Playwright report "${file}" is not valid JSON: ${String(error)}`);
+    }
+  });
+}
+
+/** Read the changed-spec allowlist; whitespace-separated so it survives shell round-trips. */
+function resolveChangedSpecs(): string[] {
+  return (process.env.FLAKE_CHANGED_SPECS ?? '').split(/\s+/).filter(Boolean);
+}
+
+/** Read the burn-in failure threshold (`>= threshold` failures is a flake). */
+function resolveThreshold(): number {
+  const raw = process.env.FLAKE_THRESHOLD ?? '2';
+  const threshold = Number.parseInt(raw, 10);
+  if (!Number.isInteger(threshold) || threshold < 1) {
+    throw new Error(`FLAKE_THRESHOLD must be a positive integer; got "${raw}".`);
+  }
+  return threshold;
+}
+
+/** Read and validate the mode so a typo fails closed instead of silently gating nothing. */
+function resolveMode(): Mode {
+  const raw = process.env.FLAKE_MODE ?? 'retry-pass';
+  const mode = MODES.find(candidate => candidate === raw);
+  if (mode === undefined) {
+    throw new Error(`FLAKE_MODE must be one of ${MODES.join(', ')}; got "${raw}".`);
+  }
+  return mode;
+}
+
+/** Emit a GitHub Actions annotation; harmless plain text off CI. */
+function annotate(level: 'warning' | 'error', finding: FlakeFinding): void {
+  process.stdout.write(`::${level} file=${finding.file}::${describeFinding(finding)}\n`);
+}
+
+/** Report findings and return the process exit code for the two blocking modes. */
+function gate(mode: Mode, findings: readonly FlakeFinding[], changed: readonly string[]): number {
+  const { blocking, advisory } = partitionByChanged(findings, changed);
+
+  for (const finding of advisory) {
+    annotate('warning', finding);
+  }
+  for (const finding of blocking) {
+    annotate('error', finding);
+  }
+
+  process.stdout.write(
+    `${mode}: ${blocking.length} blocking finding(s) in changed specs, ` +
+      `${advisory.length} pre-existing finding(s) elsewhere.\n`
+  );
+
+  if (blocking.length > 0) {
+    process.stderr.write(
+      `${mode} gate failed: a spec this pull request changed is nondeterministic. ` +
+        'Fix the race; never widen the retry budget to hide it.\n'
+    );
+    return 1;
+  }
+  return 0;
+}
+
+/** Print the advisory census as Markdown for the nightly tracking issue. */
+function census(findings: readonly FlakeFinding[]): void {
+  if (findings.length === 0) {
+    process.stdout.write('No flaky tests detected in this census run.\n');
+    return;
+  }
+  process.stdout.write(`Detected ${findings.length} flaky test(s):\n\n`);
+  for (const finding of findings) {
+    process.stdout.write(`- ${describeFinding(finding)}\n`);
+  }
+}
+
+function main(): void {
+  const mode = resolveMode();
+  const dir = resolveReportDir();
+  const files = findReportFiles(dir);
+
+  if (files.length === 0) {
+    throw new Error(
+      `No Playwright ${REPORT_FILE} found under "${dir}". A missing report must not pass ` +
+        'the flake gate vacuously — check that the e2e run produced its JSON reporter output.'
+    );
+  }
+
+  const reports = loadReports(files);
+  process.stdout.write(`Read ${files.length} Playwright report(s) from "${dir}".\n`);
+
+  if (mode === 'retry-pass') {
+    process.exitCode = gate(mode, findRetryPasses(reports), resolveChangedSpecs());
+    return;
+  }
+
+  if (mode === 'burn-in') {
+    const findings = findBurnInFailures(reports, resolveThreshold());
+    process.exitCode = gate(mode, findings, resolveChangedSpecs());
+    return;
+  }
+
+  census([...findRetryPasses(reports), ...findBurnInFailures(reports, resolveThreshold())]);
+}
+
+try {
+  main();
+} catch (error: unknown) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/ci/flaky-report.ts
+++ b/scripts/ci/flaky-report.ts
@@ -1,0 +1,190 @@
+/**
+ * Verdict logic for the e2e flake gate (issue #359).
+ *
+ * `playwright.config.ts` sets `retries: 2` in CI, so a spec that fails and then passes on a
+ * retry is reported green and the flake signal is discarded. That is how the WebKit swagger
+ * flake in #290 reached the production CodePipeline. This module reads the machine-readable
+ * Playwright JSON report and turns it into two verdicts:
+ *
+ * - **retry-pass** — a test whose reported status is `flaky` passed only because of a retry.
+ * - **burn-in** — a spec run under `--repeat-each=N --retries=0` that failed on some, but not
+ *   all, repetitions is nondeterministic.
+ *
+ * Both verdicts block only for specs the pull request actually changed; flakes elsewhere are
+ * surfaced as warnings so the pre-existing backlog does not block unrelated work.
+ */
+
+/** One attempt at a test. `retry > 0` means this attempt followed a failure. */
+export interface ReportResult {
+  status?: string;
+  retry?: number;
+}
+
+/** One test case: a spec in one project, or one `--repeat-each` repetition of it. */
+export interface ReportTest {
+  projectName?: string;
+  status?: string;
+  results?: ReportResult[];
+}
+
+/** A `test()` declaration, with one entry in `tests` per project and repetition. */
+export interface ReportSpec {
+  title?: string;
+  file?: string;
+  tests?: ReportTest[];
+}
+
+/** A `describe()` block or spec file; suites nest arbitrarily deep. */
+export interface ReportSuite {
+  file?: string;
+  specs?: ReportSpec[];
+  suites?: ReportSuite[];
+}
+
+/** The subset of Playwright's JSON report schema this gate reads. */
+export interface PlaywrightJsonReport {
+  suites?: ReportSuite[];
+}
+
+/** A spec flattened out of the suite tree, with its file path resolved. */
+export interface FlatSpec {
+  file: string;
+  title: string;
+  tests: ReportTest[];
+}
+
+/** A test identified as nondeterministic, with the evidence for it. */
+export interface FlakeFinding {
+  file: string;
+  title: string;
+  project: string;
+  failures: number;
+  runs: number;
+}
+
+/** Normalise a report or diff path so the two can be compared. */
+export function normalizePath(file: string): string {
+  return file.replace(/^\.\//, '');
+}
+
+/**
+ * Flatten Playwright's nested suite tree into one entry per spec.
+ *
+ * A spec's `file` is only set on some nodes depending on nesting, so the nearest enclosing
+ * suite's file is threaded down as the fallback.
+ */
+export function flattenSpecs(report: PlaywrightJsonReport): FlatSpec[] {
+  const flat: FlatSpec[] = [];
+
+  const walk = (suites: ReportSuite[], inheritedFile: string): void => {
+    for (const suite of suites) {
+      const file = suite.file ?? inheritedFile;
+      for (const spec of suite.specs ?? []) {
+        flat.push({
+          file: normalizePath(spec.file ?? file),
+          title: spec.title ?? '(untitled)',
+          tests: spec.tests ?? [],
+        });
+      }
+      walk(suite.suites ?? [], file);
+    }
+  };
+
+  walk(report.suites ?? [], '');
+  return flat;
+}
+
+/** Whether a spec file is one of the paths the pull request changed. */
+export function isChanged(file: string, changed: readonly string[]): boolean {
+  const normalized = normalizePath(file);
+  return changed.some(candidate => normalizePath(candidate) === normalized);
+}
+
+/** Whether a single attempt counts as a failure (a timeout is a failure, a skip is not). */
+export function isFailure(status: string | undefined): boolean {
+  return status === 'failed' || status === 'timedOut' || status === 'interrupted';
+}
+
+/**
+ * Tests that Playwright itself labelled `flaky` — they failed at least once and then passed
+ * on a retry, which the run's exit code hides entirely.
+ */
+export function findRetryPasses(reports: readonly PlaywrightJsonReport[]): FlakeFinding[] {
+  const findings: FlakeFinding[] = [];
+  for (const report of reports) {
+    for (const spec of flattenSpecs(report)) {
+      for (const test of spec.tests.filter(candidate => candidate.status === 'flaky')) {
+        const results = test.results ?? [];
+        findings.push({
+          file: spec.file,
+          title: spec.title,
+          project: test.projectName ?? 'unknown',
+          failures: results.filter(result => isFailure(result.status)).length,
+          runs: results.length,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+/**
+ * Specs that failed on some repetitions of a `--repeat-each` burn-in but not all.
+ *
+ * `threshold` implements the audit's single-failure tolerance: one failure in five absorbs a
+ * one-off infrastructure blip, two or more is a flake. A spec that fails every repetition is
+ * deterministically broken rather than flaky, so it is reported with `failures === runs` and
+ * left for the caller to classify.
+ */
+export function findBurnInFailures(
+  reports: readonly PlaywrightJsonReport[],
+  threshold: number
+): FlakeFinding[] {
+  const byKey = new Map<string, FlakeFinding>();
+
+  for (const report of reports) {
+    for (const spec of flattenSpecs(report)) {
+      for (const test of spec.tests) {
+        const project = test.projectName ?? 'unknown';
+        const key = JSON.stringify([spec.file, spec.title, project]);
+        const finding = byKey.get(key) ?? {
+          file: spec.file,
+          title: spec.title,
+          project,
+          failures: 0,
+          runs: 0,
+        };
+        finding.runs += 1;
+        if (test.status === 'unexpected') {
+          finding.failures += 1;
+        }
+        byKey.set(key, finding);
+      }
+    }
+  }
+
+  return [...byKey.values()].filter(finding => finding.failures >= threshold);
+}
+
+/** Split findings into the blocking set (changed specs) and the advisory set. */
+export function partitionByChanged(
+  findings: readonly FlakeFinding[],
+  changed: readonly string[]
+): { blocking: FlakeFinding[]; advisory: FlakeFinding[] } {
+  const blocking: FlakeFinding[] = [];
+  const advisory: FlakeFinding[] = [];
+  for (const finding of findings) {
+    if (isChanged(finding.file, changed)) {
+      blocking.push(finding);
+    } else {
+      advisory.push(finding);
+    }
+  }
+  return { blocking, advisory };
+}
+
+/** One-line description of a finding, used for annotations and the census issue body. */
+export function describeFinding(finding: FlakeFinding): string {
+  const attempts = `${finding.failures}/${finding.runs} attempt(s) failed`;
+  return `${finding.file} › ${finding.title} [${finding.project}] — ${attempts}`;
+}

--- a/src/test/memory-leak/leak-baseline.json
+++ b/src/test/memory-leak/leak-baseline.json
@@ -1,0 +1,23 @@
+{
+  "description": "Accepted memlab leak clusters (issue #354). Every entry is time-boxed debt recorded from the first honest run of the armed gate; allowedClusters is a ceiling, not a target. Adding an entry for a leak your change introduced is not allowed — fix the retainer instead. See src/test/memory-leak/utils/leakGate.js for the rules the gate applies, and CONTRIBUTING.md for the workflow.",
+  "scenarios": {
+    "servicesTooltip": {
+      "allowedClusters": 1,
+      "reason": "Pre-existing on main: hovering the services tooltip leaves one cluster of detached MUI nodes (~12KB retained). Measured by running the armed gate against an empty baseline, which correctly went red.",
+      "issue": "https://github.com/VilnaCRM-Org/website/issues/426",
+      "validUntil": "2027-02-10"
+    },
+    "swaggerInteractions": {
+      "allowedClusters": 29,
+      "reason": "Pre-existing on main and by far the largest of the three: expanding Swagger UI operations retains ~1MB across swagger-ui-react internals. Measured at 29 on four consecutive isolated runs and 28 in the full suite, where the earlier scenarios perturb GC state; pinned at the observed maximum so the ±1 does not produce a false red. A count of 30 is a real regression.",
+      "issue": "https://github.com/VilnaCRM-Org/website/issues/426",
+      "validUntil": "2027-02-10"
+    },
+    "toggleMobileMenu": {
+      "allowedClusters": 1,
+      "reason": "Pre-existing on main: opening and closing the mobile drawer leaves one cluster of detached nodes. Measured by running the armed gate against an empty baseline, which correctly went red.",
+      "issue": "https://github.com/VilnaCRM-Org/website/issues/426",
+      "validUntil": "2027-02-10"
+    }
+  }
+}

--- a/src/test/memory-leak/leak-baseline.json
+++ b/src/test/memory-leak/leak-baseline.json
@@ -9,7 +9,7 @@
     },
     "swaggerInteractions": {
       "allowedClusters": 29,
-      "reason": "Pre-existing on main and by far the largest of the three: expanding Swagger UI operations retains ~1MB across swagger-ui-react internals. Measured at 29 on four consecutive isolated runs and 28 in the full suite, where the earlier scenarios perturb GC state; pinned at the observed maximum so the ±1 does not produce a false red. A count of 30 is a real regression.",
+      "reason": "Pre-existing on main and by far the largest of the three: expanding Swagger UI operations retains ~1MB across swagger-ui-react internals. The count is environment-dependent — 29 on four isolated local runs, 28 in the full local suite, and 13 on a GitHub-hosted runner (run 31416963140) — so the ceiling is the cross-environment maximum. That deliberately makes this one entry loose on CI: it will not catch a regression from 13 up to 29 there. Pinning the CI figure instead would turn every local run red and pressure the next person into raising the allowance, which is worse. Burning the clusters down in issue #426 is what tightens this; do not raise it.",
       "issue": "https://github.com/VilnaCRM-Org/website/issues/426",
       "validUntil": "2027-02-10"
     },

--- a/src/test/memory-leak/runMemlabTests.js
+++ b/src/test/memory-leak/runMemlabTests.js
@@ -52,8 +52,14 @@ function write(line) {
   const resultsByScenario = new Map();
 
   // Scenarios whose work dir must survive the run. Populated only once a verdict exists, so
-  // an early exit leaves it empty and the `finally` below cleans up everything recorded so
-  // far rather than stranding heap snapshots on disk.
+  // an early exit leaves it empty and the `finally` below cleans up every scenario that
+  // completed rather than stranding their heap snapshots on disk.
+  //
+  // One directory deliberately survives an error: a scenario that throws inside `run()` never
+  // reaches `resultsByScenario`, so the `finally` cannot remove its partially written work
+  // dir. That is the behaviour we want — a crash mid-scenario is exactly when the partial
+  // snapshots are worth inspecting — and `ci-test-memory-leak` clears the results directory at
+  // the start of the next run, so it cannot accumulate across runs.
   /** @type {Set<string>} */
   const keepWorkDirFor = new Set();
 

--- a/src/test/memory-leak/runMemlabTests.js
+++ b/src/test/memory-leak/runMemlabTests.js
@@ -10,6 +10,7 @@ import {
   formatVerdict,
   summarizeTrace,
   TRACE_CHAR_LIMIT,
+  TRACE_COUNT_LIMIT,
 } from './utils/leakGate.js';
 
 const { run, analyze } = memlabApi;
@@ -47,6 +48,8 @@ function write(line) {
   const clustersByScenario = {};
   /** @type {Record<string, unknown[]>} */
   const tracesByScenario = {};
+  /** @type {Map<string, { cleanup: () => void }>} */
+  const resultsByScenario = new Map();
 
   for (const testFilePath of testFilePaths) {
     const testName = path.basename(testFilePath, '.js');
@@ -67,15 +70,26 @@ function write(line) {
 
     clustersByScenario[testName] = leaks.length;
     tracesByScenario[testName] = leaks;
+    resultsByScenario.set(testName, runResult);
 
     const analyzer = new StringAnalysis();
     await analyze(runResult, analyzer);
-
-    runResult.cleanup();
   }
 
   const today = new Date().toISOString().slice(0, 10);
   const verdict = evaluateLeakRun(clustersByScenario, baseline, today);
+
+  // `runResult.cleanup()` deletes the scenario's work dir (BaseResultReader calls
+  // fs.removeSync on it), so cleanup is deferred until the verdict is known and then skipped
+  // for the failing scenarios. Otherwise the heap snapshots would be gone before the traces
+  // below point a reader at them. Passing scenarios are still cleaned up, so a green run
+  // leaves nothing behind.
+  const failedScenarios = new Set(verdict.failures.map(failure => failure.scenario));
+  for (const [scenario, runResult] of resultsByScenario) {
+    if (!failedScenarios.has(scenario)) {
+      runResult.cleanup();
+    }
+  }
 
   // Print the retainer traces only for the scenarios that actually fail, so a red run is
   // directly actionable without burying it under the already-accepted clusters. memlab's
@@ -85,8 +99,14 @@ function write(line) {
     const traces = tracesByScenario[failure.scenario] ?? [];
     if (traces.length > 0) {
       const workDir = `${baseWorkDir}/${failure.scenario}`;
-      write(`[memlab] retainer traces for ${failure.scenario} (${workDir}):`);
-      for (const trace of traces) {
+      // Cap the count as well as each trace's length. A regression on a scenario with a
+      // large allowance (swaggerInteractions sits at 29) would otherwise print tens of KB,
+      // most of it re-describing clusters the baseline already accepts.
+      const shown = traces.slice(0, TRACE_COUNT_LIMIT);
+      const suffix =
+        traces.length > shown.length ? ` (first ${shown.length} of ${traces.length})` : '';
+      write(`[memlab] retainer traces for ${failure.scenario}${suffix} (${workDir}):`);
+      for (const trace of shown) {
         write(summarizeTrace(trace, TRACE_CHAR_LIMIT));
       }
     }

--- a/src/test/memory-leak/runMemlabTests.js
+++ b/src/test/memory-leak/runMemlabTests.js
@@ -51,72 +51,82 @@ function write(line) {
   /** @type {Map<string, { cleanup: () => void }>} */
   const resultsByScenario = new Map();
 
-  for (const testFilePath of testFilePaths) {
-    const testName = path.basename(testFilePath, '.js');
-    const workDir = `${baseWorkDir}/${testName}`;
+  // Scenarios whose work dir must survive the run. Populated only once a verdict exists, so
+  // an early exit leaves it empty and the `finally` below cleans up everything recorded so
+  // far rather than stranding heap snapshots on disk.
+  /** @type {Set<string>} */
+  const keepWorkDirFor = new Set();
 
-    const scenarioModule = await import(new URL(testFilePath, import.meta.url).href);
-    const scenario = scenarioModule.default ?? scenarioModule;
+  try {
+    for (const testFilePath of testFilePaths) {
+      const testName = path.basename(testFilePath, '.js');
+      const workDir = `${baseWorkDir}/${testName}`;
 
-    // `leaks` holds one entry per clustered leak trace. Discarding it (as this runner did
-    // before #354) is what made the job report-only.
-    const { leaks, runResult } = await run({
-      scenario,
-      consoleMode,
-      workDir,
-      skipWarmup: process.env.MEMLAB_SKIP_WARMUP === 'true',
-      debug: process.env.MEMLAB_DEBUG === 'true',
-    });
+      const scenarioModule = await import(new URL(testFilePath, import.meta.url).href);
+      const scenario = scenarioModule.default ?? scenarioModule;
 
-    clustersByScenario[testName] = leaks.length;
-    tracesByScenario[testName] = leaks;
-    resultsByScenario.set(testName, runResult);
+      // `leaks` holds one entry per clustered leak trace. Discarding it (as this runner did
+      // before #354) is what made the job report-only.
+      const { leaks, runResult } = await run({
+        scenario,
+        consoleMode,
+        workDir,
+        skipWarmup: process.env.MEMLAB_SKIP_WARMUP === 'true',
+        debug: process.env.MEMLAB_DEBUG === 'true',
+      });
 
-    const analyzer = new StringAnalysis();
-    await analyze(runResult, analyzer);
-  }
+      clustersByScenario[testName] = leaks.length;
+      tracesByScenario[testName] = leaks;
+      resultsByScenario.set(testName, runResult);
 
-  const today = new Date().toISOString().slice(0, 10);
-  const verdict = evaluateLeakRun(clustersByScenario, baseline, today);
-
-  // `runResult.cleanup()` deletes the scenario's work dir (BaseResultReader calls
-  // fs.removeSync on it), so cleanup is deferred until the verdict is known and then skipped
-  // for the failing scenarios. Otherwise the heap snapshots would be gone before the traces
-  // below point a reader at them. Passing scenarios are still cleaned up, so a green run
-  // leaves nothing behind.
-  const failedScenarios = new Set(verdict.failures.map(failure => failure.scenario));
-  for (const [scenario, runResult] of resultsByScenario) {
-    if (!failedScenarios.has(scenario)) {
-      runResult.cleanup();
+      const analyzer = new StringAnalysis();
+      await analyze(runResult, analyzer);
     }
-  }
 
-  // Print the retainer traces only for the scenarios that actually fail, so a red run is
-  // directly actionable without burying it under the already-accepted clusters. memlab's
-  // own VERBOSE output above carries the readable trace and retained sizes; these lines
-  // identify which clusters the gate rejected.
-  for (const failure of verdict.failures) {
-    const traces = tracesByScenario[failure.scenario] ?? [];
-    if (traces.length > 0) {
-      const workDir = `${baseWorkDir}/${failure.scenario}`;
-      // Cap the count as well as each trace's length. A regression on a scenario with a
-      // large allowance (swaggerInteractions sits at 29) would otherwise print tens of KB,
-      // most of it re-describing clusters the baseline already accepts.
-      const shown = traces.slice(0, TRACE_COUNT_LIMIT);
-      const suffix =
-        traces.length > shown.length ? ` (first ${shown.length} of ${traces.length})` : '';
-      write(`[memlab] retainer traces for ${failure.scenario}${suffix} (${workDir}):`);
-      for (const trace of shown) {
-        write(summarizeTrace(trace, TRACE_CHAR_LIMIT));
+    const today = new Date().toISOString().slice(0, 10);
+    const verdict = evaluateLeakRun(clustersByScenario, baseline, today);
+    for (const failure of verdict.failures) {
+      keepWorkDirFor.add(failure.scenario);
+    }
+
+    // Print the retainer traces only for the scenarios that actually fail, so a red run is
+    // directly actionable without burying it under the already-accepted clusters. memlab's
+    // own VERBOSE output above carries the readable trace and retained sizes; these lines
+    // identify which clusters the gate rejected.
+    for (const failure of verdict.failures) {
+      const traces = tracesByScenario[failure.scenario] ?? [];
+      if (traces.length > 0) {
+        const workDir = `${baseWorkDir}/${failure.scenario}`;
+        // Cap the count as well as each trace's length. A regression on a scenario with a
+        // large allowance (swaggerInteractions sits at 29) would otherwise print tens of KB,
+        // most of it re-describing clusters the baseline already accepts.
+        const shown = traces.slice(0, TRACE_COUNT_LIMIT);
+        const suffix =
+          traces.length > shown.length ? ` (first ${shown.length} of ${traces.length})` : '';
+        write(`[memlab] retainer traces for ${failure.scenario}${suffix} (${workDir}):`);
+        for (const trace of shown) {
+          write(summarizeTrace(trace, TRACE_CHAR_LIMIT));
+        }
       }
     }
-  }
 
-  for (const line of formatVerdict(verdict)) {
-    write(line);
-  }
+    for (const line of formatVerdict(verdict)) {
+      write(line);
+    }
 
-  if (!verdict.ok) {
-    process.exitCode = 1;
+    if (!verdict.ok) {
+      process.exitCode = 1;
+    }
+  } finally {
+    // `runResult.cleanup()` deletes the scenario's work dir (BaseResultReader calls
+    // fs.removeSync on it), so it cannot run inside the loop: the traces above have to be
+    // able to point a reader at a directory that still exists. Deferring it here keeps the
+    // failing scenarios' snapshots for inspection while still removing every other one,
+    // including on the error path.
+    for (const [scenario, runResult] of resultsByScenario) {
+      if (!keepWorkDirFor.has(scenario)) {
+        runResult.cleanup();
+      }
+    }
   }
 })();

--- a/src/test/memory-leak/runMemlabTests.js
+++ b/src/test/memory-leak/runMemlabTests.js
@@ -5,6 +5,13 @@ import './utils/initializeLocalization.js';
 import memlabApi from '@memlab/api';
 import heapAnalysis from '@memlab/heap-analysis';
 
+import {
+  evaluateLeakRun,
+  formatVerdict,
+  summarizeTrace,
+  TRACE_CHAR_LIMIT,
+} from './utils/leakGate.js';
+
 const { run, analyze } = memlabApi;
 const { StringAnalysis } = heapAnalysis;
 
@@ -13,6 +20,19 @@ const testsDir = './tests';
 
 const baseWorkDir = './src/test/memory-leak/results';
 const consoleMode = 'VERBOSE';
+
+/**
+ * Accepted-debt allowances for clusters that already existed when the gate was armed
+ * (issue #354). Every entry is time-boxed; see `utils/leakGate.js` for the rules.
+ */
+const baseline = JSON.parse(
+  fs.readFileSync(new URL('./leak-baseline.json', import.meta.url), 'utf8')
+);
+
+/** eslint forbids `console` in this layer, so findings go straight to the stream. */
+function write(line) {
+  process.stderr.write(`${line}\n`);
+}
 
 (async function runMemlab() {
   const testFilePaths = fs
@@ -23,6 +43,11 @@ const consoleMode = 'VERBOSE';
     .filter(test => test.endsWith('.js'))
     .map(test => `${testsDir}/${test}`);
 
+  /** @type {Record<string, number>} */
+  const clustersByScenario = {};
+  /** @type {Record<string, unknown[]>} */
+  const tracesByScenario = {};
+
   for (const testFilePath of testFilePaths) {
     const testName = path.basename(testFilePath, '.js');
     const workDir = `${baseWorkDir}/${testName}`;
@@ -30,7 +55,9 @@ const consoleMode = 'VERBOSE';
     const scenarioModule = await import(new URL(testFilePath, import.meta.url).href);
     const scenario = scenarioModule.default ?? scenarioModule;
 
-    const { runResult } = await run({
+    // `leaks` holds one entry per clustered leak trace. Discarding it (as this runner did
+    // before #354) is what made the job report-only.
+    const { leaks, runResult } = await run({
       scenario,
       consoleMode,
       workDir,
@@ -38,9 +65,38 @@ const consoleMode = 'VERBOSE';
       debug: process.env.MEMLAB_DEBUG === 'true',
     });
 
+    clustersByScenario[testName] = leaks.length;
+    tracesByScenario[testName] = leaks;
+
     const analyzer = new StringAnalysis();
     await analyze(runResult, analyzer);
 
     runResult.cleanup();
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const verdict = evaluateLeakRun(clustersByScenario, baseline, today);
+
+  // Print the retainer traces only for the scenarios that actually fail, so a red run is
+  // directly actionable without burying it under the already-accepted clusters. memlab's
+  // own VERBOSE output above carries the readable trace and retained sizes; these lines
+  // identify which clusters the gate rejected.
+  for (const failure of verdict.failures) {
+    const traces = tracesByScenario[failure.scenario] ?? [];
+    if (traces.length > 0) {
+      const workDir = `${baseWorkDir}/${failure.scenario}`;
+      write(`[memlab] retainer traces for ${failure.scenario} (${workDir}):`);
+      for (const trace of traces) {
+        write(summarizeTrace(trace, TRACE_CHAR_LIMIT));
+      }
+    }
+  }
+
+  for (const line of formatVerdict(verdict)) {
+    write(line);
+  }
+
+  if (!verdict.ok) {
+    process.exitCode = 1;
   }
 })();

--- a/src/test/memory-leak/utils/leakGate.d.ts
+++ b/src/test/memory-leak/utils/leakGate.d.ts
@@ -45,6 +45,8 @@ export interface LeakVerdict {
 
 export declare const TRACE_CHAR_LIMIT: number;
 
+export declare const TRACE_COUNT_LIMIT: number;
+
 export declare function summarizeTrace(trace: unknown, limit: number): string;
 
 export declare function describeAllowanceProblem(allowance: unknown): string | null;

--- a/src/test/memory-leak/utils/leakGate.d.ts
+++ b/src/test/memory-leak/utils/leakGate.d.ts
@@ -1,0 +1,60 @@
+// Declaration shim for the sibling gate module `leakGate.js`. The memlab runner is plain
+// ESM JavaScript executed by node inside the memory-leak container, so the module stays
+// `.js`; this exposes its surface to src/test/unit/memlab-leak-gate.test.ts under
+// `allowJs: false`.
+
+/** One accepted-debt entry in `leak-baseline.json`. */
+export interface LeakAllowance {
+  allowedClusters: number;
+  reason: string;
+  issue: string;
+  validUntil: string;
+}
+
+/** The parsed `leak-baseline.json` document. */
+export interface LeakBaseline {
+  scenarios?: Record<string, unknown>;
+}
+
+/** The kinds of finding the gate can report. */
+export type LeakFindingKind =
+  | 'new-leak'
+  | 'regression'
+  | 'expired'
+  | 'malformed-entry'
+  | 'stale-entry'
+  | 'ratchet'
+  | 'allowed';
+
+/** A single failure or notice produced by the gate. */
+export interface LeakFinding {
+  kind: LeakFindingKind;
+  scenario: string;
+  observed: number;
+  allowed: number;
+  message: string;
+}
+
+/** The verdict for one memlab run. */
+export interface LeakVerdict {
+  ok: boolean;
+  failures: LeakFinding[];
+  notices: LeakFinding[];
+  totalClusters: number;
+}
+
+export declare const TRACE_CHAR_LIMIT: number;
+
+export declare function summarizeTrace(trace: unknown, limit: number): string;
+
+export declare function describeAllowanceProblem(allowance: unknown): string | null;
+
+export declare function isExpired(validUntil: string, today: string): boolean;
+
+export declare function evaluateLeakRun(
+  observed: Record<string, number>,
+  baseline: LeakBaseline,
+  today: string
+): LeakVerdict;
+
+export declare function formatVerdict(verdict: LeakVerdict): string[];

--- a/src/test/memory-leak/utils/leakGate.js
+++ b/src/test/memory-leak/utils/leakGate.js
@@ -1,0 +1,296 @@
+/**
+ * Verdict logic for the memlab leak gate (issue #354).
+ *
+ * `runMemlabTests.js` used to discard the `leaks` array that `@memlab/api`'s `run()`
+ * returns, so a run that detected fifty leak clusters exited 0 exactly like a clean one.
+ * This module turns the per-scenario cluster counts into a pass/fail verdict against
+ * `leak-baseline.json`, which records the clusters that already existed when the gate was
+ * armed. Each baseline entry must carry a reason, a tracking issue, and an expiry date, so
+ * accepted debt stays visible and time-boxed rather than becoming silently permanent.
+ *
+ * The findings, in order of severity:
+ *
+ * - `new-leak` — clusters in a scenario with no baseline entry, i.e. a leak this change added
+ * - `regression` — more clusters than the recorded allowance
+ * - `expired` — a leaking scenario whose allowance is past its `validUntil` date
+ * - `malformed-entry` — an allowance missing a reason, an issue, or a usable expiry
+ * - `stale-entry` — an allowance for a scenario that no longer runs
+ *
+ * Counts below the allowance are reported as `ratchet` notices rather than failures: memlab
+ * cluster counts vary slightly between runs, so demanding an exact match would make the gate
+ * flaky. Lower the allowance once a notice is reported consistently.
+ */
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Characters of serialized retainer trace printed per cluster. memlab already prints the
+ * readable trace and the retained-size summary in VERBOSE mode, so this inline copy only
+ * has to identify the cluster — dumping all of it would add megabytes to every red run.
+ */
+export const TRACE_CHAR_LIMIT = 1200;
+
+/**
+ * Serialize one retainer trace, truncated to `limit` characters.
+ *
+ * @param {unknown} trace One entry of the `leaks` array `@memlab/api`'s `run()` returns.
+ * @param {number} limit
+ * @returns {string}
+ */
+export function summarizeTrace(trace, limit) {
+  const serialized = JSON.stringify(trace);
+  if (serialized.length <= limit) {
+    return serialized;
+  }
+  const dropped = serialized.length - limit;
+  const hint = 'full trace in the scenario work dir';
+  return `${serialized.slice(0, limit)}… (+${dropped} chars; ${hint})`;
+}
+
+/**
+ * Build one finding record.
+ *
+ * @param {{ kind: string, scenario: string, observed?: number, allowed?: number,
+ *   message: string }} finding
+ */
+function finding({ kind, scenario, observed = 0, allowed = 0, message }) {
+  return { kind, scenario, observed, allowed, message };
+}
+
+/**
+ * Why a baseline entry cannot be used, or `null` when it is well-formed.
+ *
+ * An allowance with no reason, no tracking issue, or no readable deadline is indefinite,
+ * unattributed debt — exactly what this gate exists to prevent — so it fails the run rather
+ * than quietly defaulting.
+ *
+ * @param {unknown} allowance
+ * @returns {string | null}
+ */
+export function describeAllowanceProblem(allowance) {
+  if (typeof allowance !== 'object' || allowance === null) {
+    return 'the entry must be an object';
+  }
+  const { allowedClusters, reason, issue, validUntil } = allowance;
+  if (!Number.isInteger(allowedClusters) || allowedClusters < 1) {
+    return 'allowedClusters must be a positive integer';
+  }
+  if (typeof reason !== 'string' || reason.trim() === '') {
+    return 'reason must say why the clusters are accepted';
+  }
+  if (typeof issue !== 'string' || issue.trim() === '') {
+    return 'issue must link the burn-down ticket';
+  }
+  if (typeof validUntil !== 'string' || !ISO_DATE.test(validUntil)) {
+    return 'validUntil must be a YYYY-MM-DD date';
+  }
+  return null;
+}
+
+/**
+ * Whether an allowance's expiry date has passed. Dates are ISO-8601, so a lexicographic
+ * comparison is a chronological one.
+ *
+ * @param {string} validUntil
+ * @param {string} today
+ * @returns {boolean}
+ */
+export function isExpired(validUntil, today) {
+  return validUntil < today;
+}
+
+/**
+ * Audit the baseline itself: every entry must be well-formed and must still name a scenario
+ * that runs.
+ *
+ * @param {Record<string, unknown>} allowances
+ * @param {Record<string, number>} observed
+ * @returns {{ failures: object[], usable: Map<string, object>, malformed: Set<string> }}
+ */
+function auditBaseline(allowances, observed) {
+  const failures = [];
+  const usable = new Map();
+  const malformed = new Set();
+
+  for (const [scenario, allowance] of Object.entries(allowances)) {
+    const problem = describeAllowanceProblem(allowance);
+    if (problem !== null) {
+      malformed.add(scenario);
+      failures.push(
+        finding({
+          kind: 'malformed-entry',
+          scenario,
+          message: `leak-baseline.json entry "${scenario}" is unusable: ${problem}.`,
+        })
+      );
+    } else if (Object.hasOwn(observed, scenario)) {
+      usable.set(scenario, allowance);
+    } else {
+      failures.push(
+        finding({
+          kind: 'stale-entry',
+          scenario,
+          allowed: allowance.allowedClusters,
+          message:
+            `leak-baseline.json allows leaks for "${scenario}", which is not one of the ` +
+            'scenarios that ran. Remove the entry or fix the scenario name.',
+        })
+      );
+    }
+  }
+
+  return { failures, usable, malformed };
+}
+
+/**
+ * Classify one scenario's cluster count against its allowance.
+ *
+ * @param {{ scenario: string, count: number, allowance: object | undefined, today: string }} input
+ * @returns {object}
+ */
+function classifyScenario({ scenario, count, allowance, today }) {
+  if (allowance === undefined) {
+    return finding({
+      kind: 'new-leak',
+      scenario,
+      observed: count,
+      message:
+        `${scenario} detected ${count} leak cluster(s) and has no baseline entry. ` +
+        'Fix the leak; do not add an allowance for a leak this change introduced.',
+    });
+  }
+
+  const allowed = allowance.allowedClusters;
+
+  if (count > allowed) {
+    return finding({
+      kind: 'regression',
+      scenario,
+      observed: count,
+      allowed,
+      message:
+        `${scenario} detected ${count} leak cluster(s), above its baseline allowance of ` +
+        `${allowed}. Fix the new retainers; never raise the allowance to absorb them.`,
+    });
+  }
+
+  if (isExpired(allowance.validUntil, today)) {
+    return finding({
+      kind: 'expired',
+      scenario,
+      observed: count,
+      allowed,
+      message:
+        `${scenario}'s baseline allowance expired on ${allowance.validUntil}. ` +
+        `Burn the clusters down or re-triage them in ${allowance.issue}.`,
+    });
+  }
+
+  if (count < allowed) {
+    return finding({
+      kind: 'ratchet',
+      scenario,
+      observed: count,
+      allowed,
+      message:
+        `${scenario} detected ${count} of ${allowed} allowed cluster(s); ` +
+        `lower the allowance to ${count}.`,
+    });
+  }
+
+  return finding({
+    kind: 'allowed',
+    scenario,
+    observed: count,
+    allowed,
+    message:
+      `${scenario} detected ${count} allowed cluster(s) ` +
+      `(${allowance.issue}, expires ${allowance.validUntil}).`,
+  });
+}
+
+/** Findings that describe accepted state rather than a failure. */
+const NOTICE_KINDS = new Set(['allowed', 'ratchet']);
+
+/**
+ * Grade one scenario's result, or `null` when it needs no finding.
+ *
+ * A scenario whose baseline entry is malformed is already reported by `auditBaseline`, so
+ * it is skipped here rather than reported twice.
+ *
+ * @param {{ scenario: string, count: number, usable: Map<string, object>,
+ *   malformed: Set<string>, today: string }} input
+ * @returns {object | null}
+ */
+function gradeScenario({ scenario, count, usable, malformed, today }) {
+  if (malformed.has(scenario)) {
+    return null;
+  }
+
+  const allowance = usable.get(scenario);
+
+  if (count === 0) {
+    if (allowance === undefined) {
+      return null;
+    }
+    return finding({
+      kind: 'ratchet',
+      scenario,
+      allowed: allowance.allowedClusters,
+      message:
+        `${scenario} reported no leak clusters but still holds a baseline allowance. ` +
+        'Remove its entry from leak-baseline.json to lock the fix in.',
+    });
+  }
+
+  return classifyScenario({ scenario, count, allowance, today });
+}
+
+/**
+ * Compare one run's per-scenario cluster counts against the baseline.
+ *
+ * @param {Record<string, number>} observed Cluster count per scenario name, for every
+ *   scenario that ran (including the ones that leaked nothing).
+ * @param {{ scenarios?: Record<string, unknown> }} baseline Parsed `leak-baseline.json`.
+ * @param {string} today Current date as `YYYY-MM-DD`. Injected rather than read from the
+ *   clock so the verdict is testable.
+ */
+export function evaluateLeakRun(observed, baseline, today) {
+  const allowances = baseline.scenarios ?? {};
+  const { failures, usable, malformed } = auditBaseline(allowances, observed);
+  const notices = [];
+  let totalClusters = 0;
+
+  for (const [scenario, count] of Object.entries(observed)) {
+    totalClusters += count;
+    const outcome = gradeScenario({ scenario, count, usable, malformed, today });
+    if (outcome !== null) {
+      (NOTICE_KINDS.has(outcome.kind) ? notices : failures).push(outcome);
+    }
+  }
+
+  return { ok: failures.length === 0, failures, notices, totalClusters };
+}
+
+/**
+ * Render the verdict as the lines the runner writes to stderr.
+ *
+ * @param {{ ok: boolean, failures: object[], notices: object[], totalClusters: number }} verdict
+ * @returns {string[]}
+ */
+export function formatVerdict(verdict) {
+  const lines = [];
+  for (const notice of verdict.notices) {
+    lines.push(`[memlab] note: ${notice.message}`);
+  }
+  for (const failure of verdict.failures) {
+    lines.push(`[memlab] ${failure.kind}: ${failure.message}`);
+  }
+  lines.push(
+    verdict.ok
+      ? `[memlab] PASS: ${verdict.totalClusters} leak cluster(s), all within leak-baseline.json`
+      : `[memlab] FAIL: ${verdict.failures.length} unaccounted leak finding(s); ` +
+          'see the traces above'
+  );
+  return lines;
+}

--- a/src/test/memory-leak/utils/leakGate.js
+++ b/src/test/memory-leak/utils/leakGate.js
@@ -31,6 +31,12 @@ const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 export const TRACE_CHAR_LIMIT = 1200;
 
 /**
+ * Clusters printed per failing scenario. Bounds the total output on a scenario with a large
+ * allowance, where most clusters are already-accepted debt rather than the regression.
+ */
+export const TRACE_COUNT_LIMIT = 5;
+
+/**
  * Serialize one retainer trace, truncated to `limit` characters.
  *
  * @param {unknown} trace One entry of the `leaks` array `@memlab/api`'s `run()` returns.
@@ -194,7 +200,7 @@ function classifyScenario({ scenario, count, allowance, today }) {
       allowed,
       message:
         `${scenario} detected ${count} of ${allowed} allowed cluster(s); ` +
-        `lower the allowance to ${count}.`,
+        `lower the allowance to ${count} once that count is reproducible.`,
     });
   }
 
@@ -239,7 +245,10 @@ function gradeScenario({ scenario, count, usable, malformed, today }) {
       allowed: allowance.allowedClusters,
       message:
         `${scenario} reported no leak clusters but still holds a baseline allowance. ` +
-        'Remove its entry from leak-baseline.json to lock the fix in.',
+        'If it reports zero consistently, remove its entry from leak-baseline.json to lock ' +
+        'the fix in — but confirm across runs first, because a single zero can be run-to-run ' +
+        'variance and removing a still-valid entry turns the next run into a blocking ' +
+        'new-leak failure.',
     });
   }
 

--- a/src/test/memory-leak/utils/leakGate.js
+++ b/src/test/memory-leak/utils/leakGate.js
@@ -17,8 +17,11 @@
  * - `stale-entry` — an allowance for a scenario that no longer runs
  *
  * Counts below the allowance are reported as `ratchet` notices rather than failures: memlab
- * cluster counts vary slightly between runs, so demanding an exact match would make the gate
- * flaky. Lower the allowance once a notice is reported consistently.
+ * cluster counts vary between runs and, more sharply, between environments — the same
+ * scenario clusters at 13 on a GitHub-hosted runner and 28-29 locally — so demanding an
+ * exact match would make the gate flaky. An allowance is therefore the maximum seen across
+ * environments, which keeps it honest at the cost of some slack on the environment that
+ * clusters lowest. Lower it only when the smaller count holds everywhere.
  */
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
@@ -200,7 +203,9 @@ function classifyScenario({ scenario, count, allowance, today }) {
       allowed,
       message:
         `${scenario} detected ${count} of ${allowed} allowed cluster(s); ` +
-        `lower the allowance to ${count} once that count is reproducible.`,
+        `lower the allowance to ${count} only if that count holds in every environment — ` +
+        'CI runners and local machines cluster differently, so a lower CI count does not ' +
+        'mean the allowance is stale.',
     });
   }
 

--- a/src/test/unit/flaky-report.test.ts
+++ b/src/test/unit/flaky-report.test.ts
@@ -77,6 +77,26 @@ describe('e2e flake gate report parsing', () => {
     it('treats an empty changed list as nothing changed', () => {
       expect(isChanged('src/test/e2e/a.spec.ts', [])).toBe(false);
     });
+
+    // Exact matching is only correct because Playwright reports paths relative to
+    // `config.rootDir`, and rootDir here is the repository root (playwright.config.ts sits
+    // at the top level), so report paths are byte-identical to `git diff --name-only`
+    // output. Verified against a real CI shard report, whose suites carry
+    // `file: "src/test/e2e/check-date.spec.ts"` with `rootDir: "/app"`. If the config ever
+    // moves into a subdirectory, report paths become testDir-relative and this breaks.
+    it('matches the repository-root-relative paths a real report emits', () => {
+      const specs = flattenSpecs({
+        suites: [
+          {
+            file: 'src/test/e2e/check-date.spec.ts',
+            specs: [{ title: 'Checking the current year', tests: [] }],
+          },
+        ],
+      });
+
+      expect(specs[0]?.file).toBe('src/test/e2e/check-date.spec.ts');
+      expect(isChanged(specs[0]?.file ?? '', ['src/test/e2e/check-date.spec.ts'])).toBe(true);
+    });
   });
 
   describe('isFailure', () => {

--- a/src/test/unit/flaky-report.test.ts
+++ b/src/test/unit/flaky-report.test.ts
@@ -1,0 +1,282 @@
+import {
+  describeFinding,
+  findBurnInFailures,
+  findRetryPasses,
+  flattenSpecs,
+  isChanged,
+  isFailure,
+  normalizePath,
+  partitionByChanged,
+  type PlaywrightJsonReport,
+  type ReportTest,
+} from '../../../scripts/ci/flaky-report';
+
+/** A Playwright report holding one spec file with the given tests. */
+function report(file: string, title: string, tests: ReportTest[]): PlaywrightJsonReport {
+  return { suites: [{ file, specs: [{ title, file, tests }] }] };
+}
+
+/** `--repeat-each` repetitions of one spec in one project, `pass`/`fail` per repetition. */
+function repetitions(project: string, outcomes: readonly ('pass' | 'fail')[]): ReportTest[] {
+  return outcomes.map(outcome => ({
+    projectName: project,
+    status: outcome === 'fail' ? 'unexpected' : 'expected',
+    results: [{ status: outcome === 'fail' ? 'failed' : 'passed', retry: 0 }],
+  }));
+}
+
+describe('e2e flake gate report parsing', () => {
+  describe('flattenSpecs', () => {
+    it('flattens nested describe blocks and inherits the enclosing file path', () => {
+      const nested: PlaywrightJsonReport = {
+        suites: [
+          {
+            file: 'src/test/e2e/a.spec.ts',
+            specs: [{ title: 'top level', tests: [] }],
+            suites: [{ specs: [{ title: 'nested', tests: [] }] }],
+          },
+        ],
+      };
+
+      expect(flattenSpecs(nested)).toEqual([
+        { file: 'src/test/e2e/a.spec.ts', title: 'top level', tests: [] },
+        { file: 'src/test/e2e/a.spec.ts', title: 'nested', tests: [] },
+      ]);
+    });
+
+    it('returns nothing for an empty report rather than throwing', () => {
+      expect(flattenSpecs({})).toEqual([]);
+      expect(flattenSpecs({ suites: [] })).toEqual([]);
+    });
+
+    it('skips a suite that declares no specs', () => {
+      expect(flattenSpecs({ suites: [{ file: 'a.spec.ts' }] })).toEqual([]);
+    });
+
+    it('falls back to a placeholder title when a spec has none', () => {
+      expect(flattenSpecs({ suites: [{ file: 'a.spec.ts', specs: [{}] }] })).toEqual([
+        { file: 'a.spec.ts', title: '(untitled)', tests: [] },
+      ]);
+    });
+  });
+
+  describe('normalizePath and isChanged', () => {
+    it('treats a "./"-prefixed report path as the same file as the diff path', () => {
+      expect(normalizePath('./src/test/e2e/a.spec.ts')).toBe('src/test/e2e/a.spec.ts');
+      expect(isChanged('./src/test/e2e/a.spec.ts', ['src/test/e2e/a.spec.ts'])).toBe(true);
+    });
+
+    it('does not treat an unrelated spec as changed', () => {
+      expect(isChanged('src/test/e2e/a.spec.ts', ['src/test/e2e/b.spec.ts'])).toBe(false);
+    });
+
+    it('does not match on a path prefix', () => {
+      expect(isChanged('src/test/e2e/a.spec.ts', ['src/test/e2e/a.spec.ts.bak'])).toBe(false);
+    });
+
+    it('treats an empty changed list as nothing changed', () => {
+      expect(isChanged('src/test/e2e/a.spec.ts', [])).toBe(false);
+    });
+  });
+
+  describe('isFailure', () => {
+    it.each(['failed', 'timedOut', 'interrupted'])('counts %s as a failure', status => {
+      expect(isFailure(status)).toBe(true);
+    });
+
+    it.each(['passed', 'skipped', undefined])('does not count %s as a failure', status => {
+      expect(isFailure(status)).toBe(false);
+    });
+  });
+
+  describe('findRetryPasses', () => {
+    it('flags a test Playwright reported as flaky, counting its failed attempts', () => {
+      const findings = findRetryPasses([
+        report('src/test/e2e/a.spec.ts', 'logs in', [
+          {
+            projectName: 'webkit',
+            status: 'flaky',
+            results: [
+              { status: 'failed', retry: 0 },
+              { status: 'passed', retry: 1 },
+            ],
+          },
+        ]),
+      ]);
+
+      expect(findings).toEqual([
+        {
+          file: 'src/test/e2e/a.spec.ts',
+          title: 'logs in',
+          project: 'webkit',
+          failures: 1,
+          runs: 2,
+        },
+      ]);
+    });
+
+    it('ignores clean passes and hard failures', () => {
+      const findings = findRetryPasses([
+        report('a.spec.ts', 'passes', [{ projectName: 'chromium', status: 'expected' }]),
+        report('b.spec.ts', 'breaks', [{ projectName: 'chromium', status: 'unexpected' }]),
+      ]);
+
+      expect(findings).toEqual([]);
+    });
+
+    it('collects flakes across every shard report', () => {
+      const findings = findRetryPasses([
+        report('a.spec.ts', 'one', [{ projectName: 'chromium', status: 'flaky', results: [] }]),
+        report('b.spec.ts', 'two', [{ projectName: 'firefox', status: 'flaky', results: [] }]),
+      ]);
+
+      expect(findings.map(finding => finding.file)).toEqual(['a.spec.ts', 'b.spec.ts']);
+    });
+
+    it('reports an unnamed project as unknown instead of dropping the finding', () => {
+      const findings = findRetryPasses([report('a.spec.ts', 'one', [{ status: 'flaky' }])]);
+
+      expect(findings).toEqual([
+        { file: 'a.spec.ts', title: 'one', project: 'unknown', failures: 0, runs: 0 },
+      ]);
+    });
+  });
+
+  describe('findBurnInFailures', () => {
+    it('flags a spec that failed on two of five repetitions', () => {
+      const findings = findBurnInFailures(
+        [
+          report(
+            'src/test/e2e/a.spec.ts',
+            'races',
+            repetitions('chromium', ['pass', 'fail', 'pass', 'fail', 'pass'])
+          ),
+        ],
+        2
+      );
+
+      expect(findings).toEqual([
+        {
+          file: 'src/test/e2e/a.spec.ts',
+          title: 'races',
+          project: 'chromium',
+          failures: 2,
+          runs: 5,
+        },
+      ]);
+    });
+
+    it('tolerates a single failure as a one-off infrastructure blip', () => {
+      const findings = findBurnInFailures(
+        [report('a.spec.ts', 'blips', repetitions('chromium', ['pass', 'fail', 'pass']))],
+        2
+      );
+
+      expect(findings).toEqual([]);
+    });
+
+    it('still reports a spec that failed every repetition', () => {
+      const findings = findBurnInFailures(
+        [report('a.spec.ts', 'broken', repetitions('chromium', ['fail', 'fail', 'fail']))],
+        2
+      );
+
+      expect(findings[0]).toMatchObject({ failures: 3, runs: 3 });
+    });
+
+    it('keeps projects separate so a WebKit-only flake is not diluted', () => {
+      const findings = findBurnInFailures(
+        [
+          report('a.spec.ts', 'races', [
+            ...repetitions('chromium', ['pass', 'pass', 'pass']),
+            ...repetitions('webkit', ['fail', 'fail', 'pass']),
+          ]),
+        ],
+        2
+      );
+
+      expect(findings).toEqual([
+        { file: 'a.spec.ts', title: 'races', project: 'webkit', failures: 2, runs: 3 },
+      ]);
+    });
+
+    it('accumulates repetitions of the same spec split across shard reports', () => {
+      const findings = findBurnInFailures(
+        [
+          report('a.spec.ts', 'races', repetitions('chromium', ['fail'])),
+          report('a.spec.ts', 'races', repetitions('chromium', ['fail', 'pass'])),
+        ],
+        2
+      );
+
+      expect(findings).toEqual([
+        { file: 'a.spec.ts', title: 'races', project: 'chromium', failures: 2, runs: 3 },
+      ]);
+    });
+
+    it('honours a stricter threshold of one', () => {
+      const findings = findBurnInFailures(
+        [report('a.spec.ts', 'blips', repetitions('chromium', ['pass', 'fail']))],
+        1
+      );
+
+      expect(findings).toHaveLength(1);
+    });
+
+    it('returns nothing when no test ran', () => {
+      expect(findBurnInFailures([{}], 2)).toEqual([]);
+    });
+
+    it('reports an unnamed project as unknown instead of dropping the repetitions', () => {
+      const findings = findBurnInFailures(
+        [
+          report('a.spec.ts', 'races', [
+            { status: 'unexpected' },
+            { status: 'unexpected' },
+            { status: 'expected' },
+          ]),
+        ],
+        2
+      );
+
+      expect(findings).toEqual([
+        { file: 'a.spec.ts', title: 'races', project: 'unknown', failures: 2, runs: 3 },
+      ]);
+    });
+  });
+
+  describe('partitionByChanged', () => {
+    it('blocks on changed specs and only warns about the pre-existing backlog', () => {
+      const findings = findRetryPasses([
+        report('src/test/e2e/changed.spec.ts', 'a', [{ status: 'flaky' }]),
+        report('src/test/e2e/legacy.spec.ts', 'b', [{ status: 'flaky' }]),
+      ]);
+
+      const { blocking, advisory } = partitionByChanged(findings, ['src/test/e2e/changed.spec.ts']);
+
+      expect(blocking.map(finding => finding.file)).toEqual(['src/test/e2e/changed.spec.ts']);
+      expect(advisory.map(finding => finding.file)).toEqual(['src/test/e2e/legacy.spec.ts']);
+    });
+
+    it('classes every finding as advisory when the diff touched no spec', () => {
+      const findings = findRetryPasses([report('a.spec.ts', 'a', [{ status: 'flaky' }])]);
+
+      expect(partitionByChanged(findings, []).blocking).toEqual([]);
+      expect(partitionByChanged(findings, []).advisory).toHaveLength(1);
+    });
+  });
+
+  describe('describeFinding', () => {
+    it('names the file, title, project and failure ratio', () => {
+      expect(
+        describeFinding({
+          file: 'a.spec.ts',
+          title: 'races',
+          project: 'webkit',
+          failures: 2,
+          runs: 5,
+        })
+      ).toBe('a.spec.ts › races [webkit] — 2/5 attempt(s) failed');
+    });
+  });
+});

--- a/src/test/unit/memlab-leak-gate.test.ts
+++ b/src/test/unit/memlab-leak-gate.test.ts
@@ -1,0 +1,251 @@
+import {
+  describeAllowanceProblem,
+  evaluateLeakRun,
+  formatVerdict,
+  isExpired,
+  summarizeTrace,
+  TRACE_CHAR_LIMIT,
+  type LeakAllowance,
+  type LeakBaseline,
+} from '../memory-leak/utils/leakGate';
+
+const TODAY = '2026-08-10';
+
+const VALID_ALLOWANCE: LeakAllowance = {
+  allowedClusters: 2,
+  reason: 'pre-existing when the gate was armed',
+  issue: 'https://github.com/VilnaCRM-Org/website/issues/354',
+  validUntil: '2027-02-10',
+};
+
+/** A baseline holding one allowance for `scenario`, with optional field overrides. */
+function baseline(scenario: string, overrides: Partial<LeakAllowance> = {}): LeakBaseline {
+  return { scenarios: { [scenario]: { ...VALID_ALLOWANCE, ...overrides } } };
+}
+
+describe('memlab leak gate', () => {
+  describe('describeAllowanceProblem', () => {
+    it('accepts a fully specified allowance', () => {
+      expect(describeAllowanceProblem(VALID_ALLOWANCE)).toBeNull();
+    });
+
+    it.each([null, 'two', 42])('rejects the non-object entry %p', value => {
+      expect(describeAllowanceProblem(value)).toBe('the entry must be an object');
+    });
+
+    it.each([0, -1, 1.5, '2', undefined])('rejects allowedClusters %p', value => {
+      expect(describeAllowanceProblem({ ...VALID_ALLOWANCE, allowedClusters: value })).toBe(
+        'allowedClusters must be a positive integer'
+      );
+    });
+
+    it.each(['', '   ', undefined])('rejects the reason %p', value => {
+      expect(describeAllowanceProblem({ ...VALID_ALLOWANCE, reason: value })).toBe(
+        'reason must say why the clusters are accepted'
+      );
+    });
+
+    it.each(['', undefined])('rejects the issue link %p', value => {
+      expect(describeAllowanceProblem({ ...VALID_ALLOWANCE, issue: value })).toBe(
+        'issue must link the burn-down ticket'
+      );
+    });
+
+    it.each(['', 'soon', '10-08-2026', undefined])('rejects the expiry %p', value => {
+      expect(describeAllowanceProblem({ ...VALID_ALLOWANCE, validUntil: value })).toBe(
+        'validUntil must be a YYYY-MM-DD date'
+      );
+    });
+  });
+
+  describe('summarizeTrace', () => {
+    it('serializes a short trace unchanged', () => {
+      expect(summarizeTrace({ node: 'Detached HTMLDivElement' }, TRACE_CHAR_LIMIT)).toBe(
+        '{"node":"Detached HTMLDivElement"}'
+      );
+    });
+
+    it('truncates a trace past the limit and says how much was dropped', () => {
+      const trace = { node: 'x'.repeat(50) };
+      const dropped = JSON.stringify(trace).length - 20;
+
+      const summary = summarizeTrace(trace, 20);
+
+      expect(summary.slice(0, 20)).toBe(JSON.stringify(trace).slice(0, 20));
+      expect(summary).toContain(`… (+${dropped} chars; full trace in the scenario work dir)`);
+    });
+
+    it('keeps a trace exactly on the limit intact', () => {
+      const serialized = JSON.stringify({ a: 1 });
+
+      expect(summarizeTrace({ a: 1 }, serialized.length)).toBe(serialized);
+    });
+
+    it('caps CI output well below a raw dump', () => {
+      expect(TRACE_CHAR_LIMIT).toBeLessThanOrEqual(2000);
+    });
+  });
+
+  describe('isExpired', () => {
+    it('accepts a deadline in the future', () => {
+      expect(isExpired('2027-02-10', TODAY)).toBe(false);
+    });
+
+    it('accepts the deadline day itself and expires the day after', () => {
+      expect(isExpired('2026-08-10', TODAY)).toBe(false);
+      expect(isExpired('2026-08-09', TODAY)).toBe(true);
+    });
+  });
+
+  describe('evaluateLeakRun', () => {
+    it('passes a run with no leak clusters and no allowances', () => {
+      const verdict = evaluateLeakRun({ logoNavigation: 0 }, { scenarios: {} }, TODAY);
+
+      expect(verdict.ok).toBe(true);
+      expect(verdict.failures).toEqual([]);
+      expect(verdict.notices).toEqual([]);
+      expect(verdict.totalClusters).toBe(0);
+    });
+
+    it('fails a scenario that leaks with no baseline entry', () => {
+      const verdict = evaluateLeakRun({ fillForm: 3 }, { scenarios: {} }, TODAY);
+
+      expect(verdict.ok).toBe(false);
+      expect(verdict.failures).toHaveLength(1);
+      expect(verdict.failures[0]).toMatchObject({
+        kind: 'new-leak',
+        scenario: 'fillForm',
+        observed: 3,
+      });
+    });
+
+    it('fails a scenario that leaks more than its allowance', () => {
+      const verdict = evaluateLeakRun({ fillForm: 3 }, baseline('fillForm'), TODAY);
+
+      expect(verdict.ok).toBe(false);
+      expect(verdict.failures[0]).toMatchObject({ kind: 'regression', observed: 3, allowed: 2 });
+    });
+
+    it('passes a scenario sitting exactly on its allowance', () => {
+      const verdict = evaluateLeakRun({ fillForm: 2 }, baseline('fillForm'), TODAY);
+
+      expect(verdict.ok).toBe(true);
+      expect(verdict.notices[0]).toMatchObject({ kind: 'allowed', observed: 2 });
+      expect(verdict.notices[0]?.message).toContain('expires 2027-02-10');
+    });
+
+    it('passes but asks for a ratchet when a scenario leaks less than allowed', () => {
+      const verdict = evaluateLeakRun({ fillForm: 1 }, baseline('fillForm'), TODAY);
+
+      expect(verdict.ok).toBe(true);
+      expect(verdict.notices[0]).toMatchObject({ kind: 'ratchet', observed: 1, allowed: 2 });
+      expect(verdict.notices[0]?.message).toContain('lower the allowance to 1');
+    });
+
+    it('fails once a leaking scenario passes its expiry date', () => {
+      const verdict = evaluateLeakRun(
+        { fillForm: 2 },
+        baseline('fillForm', { validUntil: '2026-01-01' }),
+        TODAY
+      );
+
+      expect(verdict.ok).toBe(false);
+      expect(verdict.failures[0]).toMatchObject({ kind: 'expired' });
+    });
+
+    it('reports a regression ahead of an expiry on the same scenario', () => {
+      const verdict = evaluateLeakRun(
+        { fillForm: 5 },
+        baseline('fillForm', { allowedClusters: 1, validUntil: '2026-01-01' }),
+        TODAY
+      );
+
+      expect(verdict.failures).toHaveLength(1);
+      expect(verdict.failures[0]?.kind).toBe('regression');
+    });
+
+    it('fails on a baseline entry for a scenario that did not run', () => {
+      const verdict = evaluateLeakRun({ logoNavigation: 0 }, baseline('deletedScenario'), TODAY);
+
+      expect(verdict.ok).toBe(false);
+      expect(verdict.failures[0]).toMatchObject({
+        kind: 'stale-entry',
+        scenario: 'deletedScenario',
+        allowed: 2,
+      });
+    });
+
+    it('fails on an allowance with no tracking issue instead of defaulting', () => {
+      const verdict = evaluateLeakRun({ fillForm: 2 }, baseline('fillForm', { issue: '' }), TODAY);
+
+      expect(verdict.ok).toBe(false);
+      expect(verdict.failures).toHaveLength(1);
+      expect(verdict.failures[0]).toMatchObject({ kind: 'malformed-entry' });
+      expect(verdict.failures[0]?.message).toContain('issue must link the burn-down ticket');
+    });
+
+    it('does not also report a new-leak for a scenario whose entry is malformed', () => {
+      const verdict = evaluateLeakRun(
+        { fillForm: 9 },
+        baseline('fillForm', { validUntil: 'whenever' }),
+        TODAY
+      );
+
+      expect(verdict.failures.map(failure => failure.kind)).toEqual(['malformed-entry']);
+      expect(verdict.totalClusters).toBe(9);
+    });
+
+    it('asks for removal when an allowed scenario stops leaking', () => {
+      const verdict = evaluateLeakRun({ fillForm: 0 }, baseline('fillForm'), TODAY);
+
+      expect(verdict.ok).toBe(true);
+      expect(verdict.notices[0]).toMatchObject({ kind: 'ratchet', observed: 0, allowed: 2 });
+      expect(verdict.notices[0]?.message).toContain('Remove its entry');
+    });
+
+    it('sums clusters across every scenario', () => {
+      const verdict = evaluateLeakRun(
+        { fillForm: 2, logoNavigation: 0, swaggerInteractions: 4 },
+        { scenarios: {} },
+        TODAY
+      );
+
+      expect(verdict.totalClusters).toBe(6);
+      expect(verdict.failures).toHaveLength(2);
+    });
+
+    it('treats a baseline with no scenarios map as allowing nothing', () => {
+      const verdict = evaluateLeakRun({ fillForm: 1 }, {}, TODAY);
+
+      expect(verdict.ok).toBe(false);
+      expect(verdict.failures[0]?.kind).toBe('new-leak');
+    });
+
+    it('does not mistake an inherited property name for an allowance', () => {
+      const verdict = evaluateLeakRun({ constructor: 1 }, { scenarios: {} }, TODAY);
+
+      expect(verdict.failures[0]).toMatchObject({ kind: 'new-leak', scenario: 'constructor' });
+    });
+  });
+
+  describe('formatVerdict', () => {
+    it('ends a clean run with a PASS line carrying the cluster total', () => {
+      const lines = formatVerdict(evaluateLeakRun({ fillForm: 2 }, baseline('fillForm'), TODAY));
+
+      expect(lines[lines.length - 1]).toBe(
+        '[memlab] PASS: 2 leak cluster(s), all within leak-baseline.json'
+      );
+      expect(lines[0]).toBe(
+        '[memlab] note: fillForm detected 2 allowed cluster(s) ' +
+          '(https://github.com/VilnaCRM-Org/website/issues/354, expires 2027-02-10).'
+      );
+    });
+
+    it('ends a red run with a FAIL line and prefixes each failure with its kind', () => {
+      const lines = formatVerdict(evaluateLeakRun({ fillForm: 9 }, { scenarios: {} }, TODAY));
+
+      expect(lines.some(line => line.startsWith('[memlab] new-leak:'))).toBe(true);
+      expect(lines[lines.length - 1]).toContain('FAIL: 1 unaccounted leak finding(s)');
+    });
+  });
+});

--- a/src/test/unit/memlab-leak-gate.test.ts
+++ b/src/test/unit/memlab-leak-gate.test.ts
@@ -5,6 +5,7 @@ import {
   isExpired,
   summarizeTrace,
   TRACE_CHAR_LIMIT,
+  TRACE_COUNT_LIMIT,
   type LeakAllowance,
   type LeakBaseline,
 } from '../memory-leak/utils/leakGate';
@@ -83,6 +84,13 @@ describe('memlab leak gate', () => {
 
     it('caps CI output well below a raw dump', () => {
       expect(TRACE_CHAR_LIMIT).toBeLessThanOrEqual(2000);
+    });
+
+    it('caps the number of clusters printed per failing scenario', () => {
+      // A regression on a scenario with a large allowance (swaggerInteractions sits at 29)
+      // would otherwise print every cluster, most of them already-accepted debt.
+      expect(TRACE_COUNT_LIMIT).toBeGreaterThan(0);
+      expect(TRACE_COUNT_LIMIT).toBeLessThanOrEqual(10);
     });
   });
 
@@ -200,7 +208,7 @@ describe('memlab leak gate', () => {
 
       expect(verdict.ok).toBe(true);
       expect(verdict.notices[0]).toMatchObject({ kind: 'ratchet', observed: 0, allowed: 2 });
-      expect(verdict.notices[0]?.message).toContain('Remove its entry');
+      expect(verdict.notices[0]?.message).toContain('confirm across runs first');
     });
 
     it('sums clusters across every scenario', () => {

--- a/tests/bats/make-target-coverage.tsv
+++ b/tests/bats/make-target-coverage.tsv
@@ -26,6 +26,8 @@ storybook-start	bats	tests/bats/makefile_targets.bats	Validated with a stubbed S
 storybook-build	bats	tests/bats/makefile_targets.bats	Validated with a stubbed Storybook binary.
 test-e2e	ci	.github/workflows/e2e-testing.yml	Executed directly by the Playwright PR workflow.
 test-e2e-shard	ci	.github/workflows/e2e-testing.yml	Executed directly by the e2e testing workflow shard matrix.
+test-e2e-burnin	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker and Playwright commands for the repeat-each burn-in.
+check-e2e-flakes	bats	tests/bats/makefile_targets.bats	Validated with a stubbed Bun invocation of the flake-report grader.
 test-e2e-ui	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker and Playwright commands.
 test-visual	ci	.github/workflows/visual-testing.yml	Executed directly by the visual testing workflow.
 test-visual-ui	bats	tests/bats/makefile_targets.bats	Validated with stubbed Docker and Playwright commands.

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -108,7 +108,7 @@ EOF
   reset_command_log
   run_make_target memory-leak-dind
   [ "$status" -eq 0 ]
-  assert_log_contains 'docker compose -p memleak -f docker-compose.memory-leak.yml up -d --wait memory-leak'
+  assert_log_contains 'docker compose -p memleak -f docker-compose.memory-leak.yml up -d --wait --build memory-leak'
   assert_log_contains 'docker compose -p memleak -f docker-compose.memory-leak.yml exec -T memory-leak rm -rf ./src/test/memory-leak/results'
   assert_log_contains 'docker compose -p memleak -f docker-compose.memory-leak.yml exec -T memory-leak sh -lc unset DISPLAY;'
   assert_log_contains 'docker compose -p memleak -f docker-compose.memory-leak.yml down'
@@ -207,6 +207,24 @@ EOF
   run_make_target e2e-direct
   [ "$status" -eq 0 ]
   assert_log_contains 'playwright test ./src/test/e2e'
+}
+
+@test "e2e flake targets repeat the changed specs and grade the report" {
+  reset_command_log
+  run_make_target test-e2e-burnin
+  [ "$status" -eq 0 ]
+  assert_log_contains 'playwright test ./src/test/e2e --repeat-each=5 --retries=0'
+  assert_log_contains 'PLAYWRIGHT_JSON_REPORT=test-results/burn-in/results.json'
+
+  reset_command_log
+  run_make_target test-e2e-burnin E2E_BURNIN_SPECS=src/test/e2e/a.spec.ts E2E_BURNIN_REPEATS=3
+  [ "$status" -eq 0 ]
+  assert_log_contains 'playwright test src/test/e2e/a.spec.ts --repeat-each=3 --retries=0'
+
+  reset_command_log
+  run_make_target check-e2e-flakes
+  [ "$status" -eq 0 ]
+  assert_log_contains 'bun x tsx scripts/ci/check-flaky-report.ts'
 }
 
 @test "maintenance targets shell out through Docker and Bun as expected" {
@@ -383,7 +401,7 @@ STUB
   run_make_target ci-test-memory-leak
   [ "$status" -eq 0 ]
   # --wait avoids racing the exec against an unready container.
-  assert_log_contains 'docker compose -p memleak -f docker-compose.memory-leak.yml up -d --wait memory-leak'
+  assert_log_contains 'docker compose -p memleak -f docker-compose.memory-leak.yml up -d --wait --build memory-leak'
   assert_log_contains 'node ./src/test/memory-leak/runMemlabTests.js'
   # Teardown must be scoped to the isolated memleak project so it never removes
   # the shared prod stack as an orphan mid-sequence in ci-test-prod, and the

--- a/tests/bats/makefile_targets.bats
+++ b/tests/bats/makefile_targets.bats
@@ -214,7 +214,7 @@ EOF
   run_make_target test-e2e-burnin
   [ "$status" -eq 0 ]
   assert_log_contains 'playwright test ./src/test/e2e --repeat-each=5 --retries=0'
-  assert_log_contains 'PLAYWRIGHT_JSON_REPORT=test-results/burn-in/results.json'
+  assert_log_contains 'PLAYWRIGHT_JSON_REPORT=burn-in-results/results.json'
 
   reset_command_log
   run_make_target test-e2e-burnin E2E_BURNIN_SPECS=src/test/e2e/a.spec.ts E2E_BURNIN_REPEATS=3


### PR DESCRIPTION
## What

Two suites have been running on every PR without asserting anything. This arms both of them.

Closes #359
Closes #354

### #359 — E2E flakes were retried away

`playwright.config.ts` sets `retries: 2` in CI, so a spec that fails and then passes is
reported **green**. Nothing in the pipeline could tell a clean pass from a retry-pass, so
genuine nondeterminism accumulated silently.

- `playwright.config.ts` now also emits the JSON reporter
  (`test-results/results.json`, overridable via `PLAYWRIGHT_JSON_REPORT`). The HTML report
  alone cannot express retry status machine-readably.
- `scripts/ci/flaky-report.ts` — pure parser over the Playwright JSON schema: flattens
  nested suites, finds retry-passes (`test.status === 'flaky'`) and burn-in failures
  (count of `unexpected` attempts per `file › title [project]`), and partitions findings
  into blocking vs advisory by whether the PR changed that spec.
- `scripts/ci/check-flaky-report.ts` — the CLI. Env-driven rather than argv-driven, the
  same choice `merge-mutation-reports.ts` made so the report path stays injection-safe.
  Walks the report dir recursively (shards land in nested artifact folders) and **fails
  closed when no report is found**.
- `.github/workflows/e2e-testing.yml` gains three jobs:
  - **changed e2e specs** — resolves the spec list once from the merge-base diff.
  - **e2e flake gate** — reads every shard's JSON report; fails when a spec *this PR
    changed* only passed on a retry. Flakes in untouched specs emit `::warning::` and do
    not block. Runs under `if: ${{ !cancelled() }}` and re-checks `needs.test.result`, so
    a shard failure cannot turn it into a skipped-and-therefore-green required check.
  - **burn in changed e2e specs** — re-runs the changed specs `--repeat-each=5
    --retries=0` and fails at two or more failures. Skipped when no spec changed.
- `.github/workflows/e2e-flake-census.yml` — nightly burn-in of the whole suite in
  `census` mode, tracked in an `e2e-flake`-labelled issue. Flakes in untouched specs are
  visible without blocking unrelated PRs.
- `make test-e2e-burnin` and `make check-e2e-flakes` expose both legs locally.

### #354 — memlab found leaks and exited 0

`src/test/memory-leak/runMemlabTests.js` discarded the `leaks` array `@memlab/api`'s
`run()` returns, so a run detecting fifty leak clusters exited exactly like a clean one.

- `src/test/memory-leak/utils/leakGate.js` grades per-scenario cluster counts against
  `leak-baseline.json` and returns findings: `new-leak` (no baseline entry),
  `regression` (over allowance), `expired` (past `validUntil`), `malformed-entry`,
  `stale-entry`, plus `ratchet`/`allowed` notices. Counts *below* the allowance are a
  notice, not a failure — memlab cluster counts vary by ±1 between runs and demanding an
  exact match would make the gate itself flaky.
- Every baseline entry **must** carry a reason, a tracking issue and a `validUntil` date.
  A malformed entry fails the run rather than silently defaulting, and an entry whose date
  has passed fails too — accepted debt cannot become permanent by neglect.
- The runner prints the retainer trace for each failing scenario (capped at
  `TRACE_CHAR_LIMIT = 1200` chars per cluster; memlab's own VERBOSE output remains the
  full evidence) and then exits non-zero.
- `make test-memory-leak` now passes `--build` to the compose `up`. The image bakes
  `src/test/memory-leak` at build time, so without it the container silently graded stale
  source. This was not theoretical: the stale image reported 14–15 clusters for
  `swaggerInteractions` where a freshly built one deterministically reports 29. Any
  baseline taken before this fix would have been measuring code that is not on `main`.

## The baseline is honest debt, not a suppression

The three entries are the clusters that already existed on `main`, measured by running the
armed gate with an **empty** baseline (which correctly went red). Burn-down is tracked in
**#426**.

| scenario | clusters | retained |
| --- | --- | --- |
| `servicesTooltip` | 1 | ~12KB detached MUI nodes |
| `swaggerInteractions` | 29 | ~1MB across `swagger-ui-react` internals |
| `toggleMobileMenu` | 1 | detached mobile-drawer nodes |

The other five scenarios leak nothing and have no entry — they are gated at zero from day
one. `swaggerInteractions` measured 29 on four consecutive isolated runs and 28 in the
full suite (the earlier scenarios perturb GC state), so it is pinned at the observed
maximum and 30 is a genuine regression. Every entry expires 2027-02-10.

That ±1 is exactly why counts *below* the allowance are a `ratchet` notice rather than a
failure: the first real green run reported `28 of 29 allowed cluster(s)` and passed. A
gate demanding an exact match would have been flaky on day one.

## Verification

Both gates were proven against seeded defects, not just unit-tested.

- **Retry-pass leg:** a temporary spec failing ~30% of the time made Playwright itself
  exit **0** ("2 passed, 1 flaky") — and the gate went red on that same run. That is
  precisely the blind spot #359 describes.
- **Burn-in leg:** the same spec reported `[firefox] — 2/5 attempt(s) failed` and failed
  the job. The advisory path (unchanged spec) emitted `::warning::` and exited 0.
- **Fail-closed:** a missing report and an invalid `FLAKE_MODE` both exit non-zero.
- **Leak gate:** first run with an empty baseline exited non-zero and named all three
  scenarios; with the baseline in place it passes and reports them as allowed notices.
- **Unit tests:** 69 new tests, both new modules at **100%** statements/branches/functions/lines.
- Also green locally: `make format`, `make lint`, `make test-unit-all`, `make test-bats`,
  qlty (eslint + prettier + actionlint + shellcheck + zizmor + editorconfig).

Two ESLint rules shaped the code rather than being suppressed: `no-console` pushed the
runner's output to `process.stderr.write`, and `no-continue` produced the
`gradeScenario() -> finding | null` split instead of three `continue` statements.

## Scope

Only #359 and #354 are in scope. The remaining `[ci-gap]` issues were left out
deliberately: some already have open PRs, and the rest touch files those PRs are editing.
This branch conflicts with none of them — it adds new files plus additive edits to
`playwright.config.ts`, the `Makefile`, the e2e workflow and the docs.

This PR changes no e2e spec, so its own burn-in leg is skipped and its flake gate runs in
advisory mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fail-closed CI gates for E2E flakes and Memlab leaks so nondeterminism and unaccounted leak clusters block PRs; nightly runs record pre-existing flakes without blocking. Closes #359 and #354.

- **New Features**
  - E2E flakes (#359)
    - `playwright.config.ts` adds a JSON reporter; `scripts/ci/flaky-report.ts` + `scripts/ci/check-flaky-report.ts` parse reports to flag retry-passes and burn-in failures.
    - `.github/workflows/e2e-testing.yml` gates retry-passes for changed specs and burns them in (`--repeat-each=5 --retries=0`, fail at ≥2); nightly `.github/workflows/e2e-flake-census.yml` files/updates an `e2e-flake` issue.
    - Make targets: `make test-e2e-burnin`, `make check-e2e-flakes`.
  - Memlab leaks (#354)
    - `src/test/memory-leak/runMemlabTests.js` reads clusters from `@memlab/api`/`@memlab/heap-analysis`, grades against `src/test/memory-leak/leak-baseline.json`, prints capped traces, and exits non-zero for new/regression/expired/malformed/stale; below-allowance emits a ratchet notice.
    - Baseline entries require a reason, a tracking issue, and `validUntil`; the `swaggerInteractions` entry documents CI vs local counts (13 vs 28–29) and pins the cross-environment max to keep the allowance honest.

- **Bug Fixes**
  - Fail-closed: the flake gate now checks both shard and changed-specs jobs; burn-in fails closed on a bad diff; missing reports fail gates.
  - Safer inputs: `FLAKE_THRESHOLD` must be a strict integer; `.spec.ts` paths with whitespace are rejected (fixtures safe — only the filtered spec list is checked).
  - Correctness: burn-in JSON goes to `burn-in-results/`; the nightly census reliably creates/updates the tracking issue and separates always-failing from flaky tests.
  - Evidence: memlab defers cleanup in a finally, keeps failing scenarios’ snapshots, and preserves a crashed scenario’s work dir for inspection; caps per-scenario trace count and length.
  - Tooling: pin Qlty’s `eslint` to `9.39.4` to avoid `eslint` 10.x breaking `eslint-plugin-react`.

<sup>Written for commit 8611632f709c89c1bd3b5ed61771523bddb6d1d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

