### PR TITLE
fix(#409): make the weekly link check report only real dead links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -65,10 +65,26 @@ jobs:
         id: lychee
         continue-on-error: true
         run: |
+          # --root-dir resolves root-relative hrefs (`/layout/favicon/favicon.svg`,
+          # `/_next/static/...`) against the site root. Without it every one of them is
+          # reported as "Cannot resolve root-relative link", which is what made this leg
+          # file 105 phantom errors a week and buried the four real ones (issue #409).
+          # `out/` IS the deployed site root, so it is the correct resolution base for
+          # Markdown and exported HTML alike. The path is the CONTAINER path -- the
+          # workspace is mounted at /repo -- and lychee requires it to be absolute.
+          #
+          # --exclude-loopback drops `http://localhost:3000`, which README.md documents as
+          # the dev-server address. It is prose that must stay, and nothing is listening on
+          # the runner, so it can only ever report "Connection refused".
+          #
+          # The blocking `offline` leg above deliberately gets neither flag: it has no
+          # `out/` to resolve against, so it keeps rejecting root-relative Markdown links
+          # outright and they never reach this leg in the first place.
           mapfile -d '' markdown_files < <(git ls-files -z '*.md')
           docker run --rm -v "$GITHUB_WORKSPACE:/repo" -w /repo \
             lycheeverse/lychee@sha256:eaff3e0a13603c9a701accfcc84f44158bb77bf36ecfa4622b626056c3463892 \
             --include-fragments --no-progress --output /repo/lychee-report.md \
+            --root-dir /repo/out --exclude-loopback \
             -- "${markdown_files[@]}" './out/**/*.html'
 
       - name: File or refresh the tracking issue on failures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ If you find an issue to work on, you are welcome to open a PR with a fix.
     it to [fork the repo](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/cloning-and-forking-repositories-from-github-desktop)!
 
 - Using the command line:
-  - [Fork the repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository)
+  - [Fork the repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#forking-a-repository)
     so that you can make your changes without affecting the original project until
     you're ready to merge them.
 
@@ -203,6 +203,23 @@ If you're unsure about how to proceed with your changes, you have two options:
 - **Contact your team lead** for guidance.
 - **Push your changes** to a branch and **open a pull request** — this will trigger
   an automated code review.
+
+### 🔗 Link Checking
+
+`.github/workflows/link-check.yml` runs [lychee](https://lychee.cli.rs/) in two legs, and
+they have deliberately different jobs:
+
+- **Offline (blocking, every PR).** Resolves relative links and `#fragment` anchors across
+  every git-tracked Markdown file, with external URLs skipped so a third party's outage can
+  never flake a required check. This is also the leg that rejects root-relative Markdown
+  links (`/some/path`) outright — keep them relative.
+- **External (advisory, Mondays).** Resolves external URLs too, over Markdown plus the built
+  `out/` export, and files or refreshes the _Weekly link check failures_ tracking issue
+  instead of blocking.
+
+Because the weekly leg reports rather than blocks, treat a noisy report as a bug in the leg:
+it is only useful while every entry is a real dead link. Fix the link, or fix the checker —
+never let phantom findings accumulate.
 
 ### 🤖 Automatic Code Review
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 # Template for modern SSR applications
 
-[![CodeScene Code Health](https://codescene.io/projects/43861/status-badges/code-health)](https://codescene.io/projects/43861)
-[![CodeScene System Mastery](https://codescene.io/projects/43861/status-badges/system-mastery)](https://codescene.io/projects/43861)
 [![codecov](https://codecov.io/gh/VilnaCRM-Org/frontend-ssr-template/graph/badge.svg?token=MPFDUSMZ2I)](https://codecov.io/gh/VilnaCRM-Org/frontend-ssr-template)
 
 ## Possibilities
@@ -403,7 +401,7 @@ folder, and documentation will appear in the `docs` folder, though you'll need t
 [API-Extractor](https://api-extractor.com/) installed.
 
 If the documentation doesn't cover what you need, search the
-[many questions on Stack Overflow](http://stackoverflow.com/questions/tagged/vilnacrm),
+[existing issues](https://github.com/VilnaCRM-Org/website/issues),
 and before you ask a question,
 [read the troubleshooting guide](https://github.com/VilnaCRM-Org/frontend-ssr-template/wiki/Troubleshooting).
 

--- a/tests/bats/link_check_workflow.bats
+++ b/tests/bats/link_check_workflow.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+#
+# Contract coverage for .github/workflows/link-check.yml (issue #409).
+#
+# The weekly `external` leg files a tracking issue with whatever lychee reports, so a
+# missing flag does not turn anything red -- it just buries the real findings. That is
+# exactly what happened: without `--root-dir`, every root-relative asset href in the built
+# export ("/layout/favicon/favicon.svg", "/_next/static/...") was reported as unresolvable,
+# and 105 of the 110 reported errors were phantoms. Pin the flags here so the next edit to
+# this workflow has to keep them.
+
+load './test_helper.bash'
+
+WORKFLOW_REL='.github/workflows/link-check.yml'
+
+# Print the executable body of one top-level job. Job names sit at exactly two spaces of
+# indent, so the next such line ends the block; every key inside a job is indented further.
+#
+# Comment lines are stripped. The steps below assert on flags, and the `run:` blocks explain
+# each flag by name in a `#` comment -- so a grep over the raw block matches the prose and
+# passes even when the flag itself has been deleted. Dropping comments first is what keeps
+# these assertions non-vacuous.
+extract_job() {
+  local job="$1"
+
+  awk -v header="  ${job}:" '
+    $0 == header { inside = 1; next }
+    inside && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { inside = 0 }
+    inside && /^[[:space:]]*#/ { next }
+    inside { print }
+  ' "$PROJECT_ROOT/$WORKFLOW_REL"
+}
+
+setup() {
+  [ -f "$PROJECT_ROOT/$WORKFLOW_REL" ]
+  OFFLINE_JOB="$BATS_TEST_TMPDIR/offline.yml"
+  EXTERNAL_JOB="$BATS_TEST_TMPDIR/external.yml"
+  extract_job offline >"$OFFLINE_JOB"
+  extract_job external >"$EXTERNAL_JOB"
+}
+
+@test "both link-check legs are extractable and non-empty" {
+  # Guards the three tests below: if a job is renamed or reindented, extract_job silently
+  # yields nothing, and the "offline leg has no --root-dir" assertion would then pass
+  # against an empty file rather than against the real job.
+  [ -s "$OFFLINE_JOB" ]
+  [ -s "$EXTERNAL_JOB" ]
+}
+
+@test "the external leg resolves root-relative links against the exported site root" {
+  # /repo is where the workflow mounts $GITHUB_WORKSPACE, and lychee requires an absolute
+  # path here. Dropping this flag re-files ~105 phantom errors a week.
+  run grep -F -- '--root-dir /repo/out' "$EXTERNAL_JOB"
+  [ "$status" -eq 0 ]
+}
+
+@test "the external leg excludes the loopback dev-server URL" {
+  # README.md documents <http://localhost:3000> as the dev-server address. Nothing listens
+  # on the runner, so without this flag it can only ever report "Connection refused".
+  run grep -F -- '--exclude-loopback' "$EXTERNAL_JOB"
+  [ "$status" -eq 0 ]
+}
+
+@test "the blocking offline leg does not resolve root-relative links" {
+  # This is what makes --root-dir safe on the external leg. The offline leg scans Markdown
+  # only and never builds the export, so it must keep rejecting root-relative Markdown
+  # links outright -- that is the gate that stops them reaching the weekly leg at all.
+  run grep -F -- '--root-dir' "$OFFLINE_JOB"
+  [ "$status" -ne 0 ]
+
+  run grep -F -- '--offline' "$OFFLINE_JOB"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #409.

## Problem

The advisory weekly leg of `link-check.yml` has been filing **110 errors**, and **105 of them are phantoms**.

lychee was invoked with no `--root-dir`, so every root-relative asset href in the built export — `/layout/favicon/*.svg`, `/_next/static/{css,media}/*` — was reported as `Cannot resolve root-relative link`, even though every one of those files ships in `out/` (`public/layout/favicon/` is committed, verified file by file). A report that is 95% noise trains readers to skip it, which is exactly how the four genuine dead links in it sat unfixed across three weekly refreshes.

So: fix the checker first, then the links it actually found.

## The checker

| Flag | Why |
| --- | --- |
| `--root-dir /repo/out` | `out/` **is** the deployed site root, so it is the correct resolution base for root-relative hrefs in Markdown and exported HTML alike. Container path (the workspace is mounted at `/repo`), and lychee requires it absolute. |
| `--exclude-loopback` | `README.md` documents `<http://localhost:3000>` as the dev-server address. It is prose that must stay, and nothing listens on the runner, so it could only ever report `Connection refused`. |

The blocking `offline` leg deliberately gets **neither** flag. It builds no export, so it keeps rejecting root-relative Markdown links outright — that is the gate which stops them ever reaching the weekly leg, and it is what makes `--root-dir` safe here rather than a blanket suppression.

## The four real findings

- **Two CodeScene badges** (`README.md`) — project `43861` redirects to `/login`; both status-badge URLs are a hard `404`. Removed: a permanently-404 badge is worse than no badge.
- **`stackoverflow.com/questions/tagged/vilnacrm`** (`README.md`) — repointed at the repository issues. The Stack Exchange API confirms the tag does not exist (`tags/vilnacrm/info` → `{"items":[]}`, against a `tags/reactjs/info` control).
- **`fork-a-repo#fork-an-example-repository`** (`CONTRIBUTING.md`) — GitHub restructured that page; the anchor is gone. Repointed to the current path + `#forking-a-repository`, both verified live.

## Regression guard

`tests/bats/link_check_workflow.bats` pins the three flag invariants. Its helper strips YAML comments before asserting, because the `run:` block explains each flag by name in prose — grepping the raw block matches the comment and passes even with the flag deleted. That vacuous-pass was caught by mutation-testing the tests themselves; each assertion now dies to exactly one mutant and only that one:

| Mutant | Kills |
| --- | --- |
| drop `--root-dir` | test 2 only |
| drop `--exclude-loopback` | test 3 only |
| add `--root-dir` to the blocking offline leg | test 4 only |

## Verification

Run against the pinned lychee image (`0.24.2`, same digest as CI) over a real `make build-out` export:

| | Total | Errors | Excluded | Exit |
| --- | --- | --- | --- | --- |
| Before | 429 | **110** | 0 | 1 |
| After | 426 | **0** | 1 (localhost) | 0 |

- Blocking `offline` leg: `320 total / 0 errors`, exit 0.
- `CI=1 make lint` — green (eslint, tsc, markdownlint, dependency-cruiser).
- `CI=1 make test-bats` — 90/90, no failures.
- `CI=1 make format` — no changes to any file in this diff.

## Scope notes

- No UI, source, or product-code changes: one workflow, two root docs, one bats file.
- No open PR touches `link-check.yml`, and no open PR's README/CONTRIBUTING hunks overlap the lines edited here — the earliest README hunk in any open PR is `@@ -99`, and the badge block is lines 5–6.
- `README.md`'s remaining `frontend-ssr-template` references are template staleness tracked by #327, not dead links — lychee resolves them 200, so they are out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops weekly link check false positives by resolving root‑relative links against the built site and excluding loopback URLs. Previously, the weekly leg flagged most `/...` asset links as “Cannot resolve root-relative link”; now it reports only real dead links.

- In `.github/workflows/link-check.yml`, add `--root-dir /repo/out` and `--exclude-loopback` to `lycheeverse/lychee` on the external weekly leg; keep the blocking offline leg without `--root-dir`.
- Add `tests/bats/link_check_workflow.bats` to pin those flags and verify the offline leg stays strict.
- Docs: remove two broken CodeScene badges from `README.md`; replace the dead StackOverflow tag link with repository Issues; fix the GitHub “fork a repo” anchor; add a brief “Link Checking” section to `CONTRIBUTING.md`.
- Required: keep Markdown links relative; root‑relative Markdown links (`/path`) will continue to fail in the blocking offline leg.

<sup>Written for commit c448ef551c1e41b9ad3f7529e6e1aaeea84dcb37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

