### PR TITLE
ci(#432): bump the pinned Alpine python3 revision to unblock every Docker check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/docker/library/node:24.18.0-alpine3.23 AS base
 
 RUN apk add --no-cache \
-    python3=3.12.13-r0\
+    python3=3.12.14-r0\
     make=4.4.1-r3 \
     g++=15.2.0-r2 \
     curl=8.20.0-r0 && \


### PR DESCRIPTION
Fixes #432. One-line unblock: **every Docker-backed check is red on `main` and on every open PR** and has been since 2026-08-16.

## Symptom

`build-artifact`, all four `e2e shard N/4`, `visual-test`, `a11y`, `memory-leak-testing`, both `lighthouse` jobs and both load-testing jobs fail in **under 90 seconds**, before a single test runs. The `base` stage of `Dockerfile` cannot build:

```text
#7 [base 2/5] RUN apk add --no-cache python3=3.12.13-r0 make=4.4.1-r3 g++=15.2.0-r2 curl=8.20.0-r0 && npm install -g bun@1.3.5 serve@14.2.0
#7 0.540 ERROR: unable to select packages:
#7 0.542   python3-3.12.14-r0:
#7 0.542     breaks: world[python3=3.12.13-r0]
make: *** [Makefile:304: build-out] Error 1
```

## Evidence that it is infrastructure, not code

- **Clean timeline cutoff on `main`.** The nightly Docker build canary from #371 — which builds all six Dockerfiles and has no PR code in it — is green through `2026-08-15T02:09:20Z` and red on `2026-08-16T02:17:06Z` and `2026-08-17T02:15:26Z`. It filed #432 on its own.
- **Cross-branch.** The same step fails identically on unrelated branches; the only common factor is the Alpine package index.
- **Nothing in the repo changed.** `alpine3.23` simply dropped `python3-3.12.13-r0` from its index in favour of `-3.12.14-r0`. Exact-version `apk` pins buy reproducible images at the cost of exactly this maintenance; the canary is what turns that cost into a one-day signal instead of a mystery.

## The change

`python3=3.12.13-r0` → `python3=3.12.14-r0`, and nothing else.

I checked the current index inside `node:24.18.0-alpine3.23` for every pin this repo carries rather than only the one `apk` happened to report first (it stops at the first unsatisfiable package):

| Pin | Indexed today | Action |
| --- | --- | --- |
| `python3=3.12.13-r0` | `3.12.14-r0` | **bumped** |
| `make=4.4.1-r3` | `4.4.1-r3` | unchanged |
| `g++=15.2.0-r2` | `15.2.0-r2` | unchanged |
| `curl=8.20.0-r0` | `8.20.0-r0` | unchanged |
| `MemoryLeak.Dockerfile`: `chromium=149.0.7827.53-r0`, `xvfb=21.1.23-r0`, `nss=3.123.1-r0`, `freetype=2.14.3-r0`, `harfbuzz=12.2.0-r0`, `ca-certificates=20260611-r0` | all still indexed | unchanged |

Verified locally: `docker build --target base -f Dockerfile .` succeeds with the bump.

Deliberately **not** done: no `apk` pin loosened to a range or dropped, no `--no-cache` removed, no failing job made `continue-on-error`. The pins are the reproducibility contract and the checks were doing their job.

## Note on `qlty check`

If `qlty check` reports "Build errored" here, it is the pre-existing ESLint-10-vs-`eslint-plugin-react`-7 breakage described in #425, which carries the `.qlty/qlty.toml` version pin that fixes it. It is unrelated to this one-line change and is deliberately left out to keep this PR minimal.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the pinned Alpine `python3` in the Docker `base` stage from `3.12.13-r0` to `3.12.14-r0` to restore all Docker-backed CI jobs. Previously, `apk` failed to satisfy the old pin and the `base` stage died before tests; with the new pin, the build completes and checks run.

**Review notes**
- Only change: `python3=3.12.13-r0` → `python3=3.12.14-r0` in `Dockerfile`.
- Cause: `alpine3.23` dropped `3.12.13-r0` in favor of `3.12.14-r0`.
- Other pins remain indexed and unchanged: `make=4.4.1-r3`, `g++=15.2.0-r2`, `curl=8.20.0-r0`.
- No pin loosened, no caching flags changed; reproducibility contract stays intact.

**Rollout**
- Merge to unblock `build-artifact`, all four `e2e` shards, `visual-test`, `a11y`, `memory-leak-testing`, both `lighthouse`, and load-testing jobs.
- No migration actions.

<sup>Written for commit 229653a75d975b516190c053ea24fde57c29e6f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VilnaCRM-Org/website/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

